### PR TITLE
新增摄像头预览开关 新增开始停止录制同条码

### DIFF
--- a/ExpressPackingMonitoring/AppConfig.cs
+++ b/ExpressPackingMonitoring/AppConfig.cs
@@ -83,6 +83,7 @@ namespace ExpressPackingMonitoring.ViewModels
         public double MaxDurationMinutes { get; set; } = 5.0;
         public double MinRecordingSeconds { get; set; } = 3.0;
         public int MinVideoFileSizeKB { get; set; } = 50;
+        public bool StartStopSameBarcode { get; set; } = true;
         public bool EnableCameraIdle { get; set; } = true;
         public double CameraIdleMinutes { get; set; } = 5.0;
 

--- a/ExpressPackingMonitoring/MainViewModel.cs
+++ b/ExpressPackingMonitoring/MainViewModel.cs
@@ -213,6 +213,8 @@ namespace ExpressPackingMonitoring.ViewModels
 
         private volatile bool _suppressVideoPreviewUpdates;
         public bool SuppressVideoPreviewUpdates { get => _suppressVideoPreviewUpdates; set => _suppressVideoPreviewUpdates = value; }
+        private bool _isPreviewEnabled = true;
+        public bool IsPreviewEnabled { get => _isPreviewEnabled; set => SetProperty(ref _isPreviewEnabled, value); }
         public BitmapSource VideoFrame { get => _videoFrame; set => SetProperty(ref _videoFrame, value); }
         public string CurrentMode { get => _currentMode; set { if (SetProperty(ref _currentMode, value)) ScheduleRefreshBarcodes(); } }
         public string CurrentOrderId { get => _currentOrderId; set => SetProperty(ref _currentOrderId, value); }
@@ -341,6 +343,7 @@ namespace ExpressPackingMonitoring.ViewModels
         public ICommand OpenPlaybackCommand { get; }
         public ICommand ToggleModeCommand { get; }
         public ICommand ToggleRecordingCommand { get; }
+        public ICommand TogglePreviewCommand { get; }
         public ICommand OpenStatsCommand { get; } // 打开统计面板
         public ICommand ResetEncoderDetectCommand { get; } // 重置编码器检测
         public ICommand CopyMonitorAddressCommand { get; }
@@ -356,6 +359,7 @@ namespace ExpressPackingMonitoring.ViewModels
                 OpenPlaybackCommand = new RelayCommand(() => { });
                 ToggleModeCommand = new RelayCommand(() => { });
                 ToggleRecordingCommand = new RelayCommand(() => { });
+                TogglePreviewCommand = new RelayCommand(() => { });
                 OpenStatsCommand = new RelayCommand(() => { });
                 CopyMonitorAddressCommand = new RelayCommand(() => { });
                 SwitchWorkstationCommand = new RelayCommand(() => { });
@@ -408,6 +412,7 @@ namespace ExpressPackingMonitoring.ViewModels
             OpenPlaybackCommand = new RelayCommand(OpenPlaybackWindow);
             ToggleModeCommand = new RelayCommand(ToggleMode);
             ToggleRecordingCommand = new RelayCommand(ToggleRecording);
+            TogglePreviewCommand = new RelayCommand(TogglePreview);
             OpenStatsCommand = new RelayCommand(OpenStatsWindow);
             ResetEncoderDetectCommand = new RelayCommand(ResetEncoderDetect);
             CopyMonitorAddressCommand = new RelayCommand(CopyMonitorAddress);
@@ -484,6 +489,23 @@ namespace ExpressPackingMonitoring.ViewModels
         }
 
         private void ToggleMode() { CurrentMode = CurrentMode == "发货" ? "退货" : "发货"; ShowToast($"已切换为: {CurrentMode}"); Speak(CurrentMode == "发货" ? "切换发货" : "切换退货"); }
+
+        private void TogglePreview()
+        {
+            IsPreviewEnabled = !IsPreviewEnabled;
+            if (!IsPreviewEnabled)
+            {
+                VideoFrame = null;
+                LastZoomRect = System.Windows.Rect.Empty;
+                Interlocked.Exchange(ref _previewUpdatePending, 0);
+            }
+            else
+            {
+                _lastPreviewFrameAt = DateTime.MinValue;
+                _lastPreviewPublishedAt = DateTime.Now;
+            }
+            ShowToast(IsPreviewEnabled ? "摄像头预览已开启" : "摄像头预览已关闭");
+        }
 
         private void PauseSpeechForRecording() => _speechService?.PauseForRecording();
 
@@ -608,6 +630,42 @@ namespace ExpressPackingMonitoring.ViewModels
 
             Debug.WriteLine($"[Zoom] 扫码事件触发: ID={upperResult}, ZoomEnabled={Config.EnableSmartZoom}, Delay={Config.ZoomDelaySeconds}");
             StartInputCooldown();
+
+            if (IsRecording && Config.StartStopSameBarcode)
+            {
+                string recordingOrderId = (_recordingOrderId ?? CurrentOrderId ?? "").ToUpper().Trim();
+                if (upperResult != recordingOrderId)
+                {
+                    ShowToast($"警告：单号不一致：{upperResult}");
+                    SpeakWarning("单号不一致");
+                    return;
+                }
+
+                if (!await _recorderLock.WaitAsync(0)) return;
+                try
+                {
+                    _stopReason = "扫码匹配停止";
+                    PauseSpeechForRecording();
+                    await InternalStopRecordingAsync();
+                    CurrentOrderId = "";
+                    ScanInputText = "";
+                    ShowToast("单号匹配，已停止录制");
+                    Speak("停止录制", cancelPrevious: false);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[HandleScan] 匹配停录异常: {ex.Message}");
+                    RuntimeLog.Error("Scan", "Matched barcode stop failed", ex);
+                }
+                finally
+                {
+                    if (!IsRecording)
+                        ResumeSpeechWhenCameraIdle();
+                    _recorderLock.Release();
+                }
+                return;
+            }
+
             CurrentOrderId = upperResult;
             if (IsRecording) _stopReason = "扫码切换";
 
@@ -1972,7 +2030,7 @@ namespace ExpressPackingMonitoring.ViewModels
 
         private void CheckPreviewWatchdog()
         {
-            if (_isDisposed || _isCameraSleeping || SuppressVideoPreviewUpdates) return;
+            if (_isDisposed || _isCameraSleeping || SuppressVideoPreviewUpdates || !IsPreviewEnabled) return;
             if (_videoSource == null || !_videoSource.IsRunning || !_cameraEverConnected) return;
             if (_lastFrameTime == DateTime.MinValue || _lastPreviewPublishedAt == DateTime.MinValue) return;
 
@@ -2026,6 +2084,7 @@ namespace ExpressPackingMonitoring.ViewModels
             _ = Application.Current.Dispatcher.InvokeAsync(() =>
             {
                 if (_isDisposed || _isCameraSleeping || SuppressVideoPreviewUpdates) return;
+                if (!IsPreviewEnabled) return;
                 ShowToast("警告：预览画面卡住，正在重连摄像头...");
                 RestartCameraWithRecordingStop();
             });
@@ -2039,7 +2098,7 @@ namespace ExpressPackingMonitoring.ViewModels
 
         private void PublishPreviewFrameIfDue(Mat frame)
         {
-            if (SuppressVideoPreviewUpdates || _isDisposed) return;
+            if (SuppressVideoPreviewUpdates || _isDisposed || !IsPreviewEnabled) return;
 
             DateTime now = DateTime.UtcNow;
             if (now - _lastPreviewFrameAt < PreviewFrameInterval) return;
@@ -2063,7 +2122,7 @@ namespace ExpressPackingMonitoring.ViewModels
                 {
                     try
                     {
-                        if (!_isDisposed && !SuppressVideoPreviewUpdates)
+                        if (!_isDisposed && !SuppressVideoPreviewUpdates && IsPreviewEnabled)
                         {
                             VideoFrame = bitmap;
                             _lastPreviewPublishedAt = DateTime.Now;

--- a/ExpressPackingMonitoring/MainWindow.xaml
+++ b/ExpressPackingMonitoring/MainWindow.xaml
@@ -100,6 +100,7 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
                         <Grid Grid.Column="0" Margin="0,0,20,0">
@@ -171,7 +172,39 @@
                             </Grid>
                         </Grid>
 
-                        <Button Grid.Column="1" Command="{Binding ToggleRecordingCommand}" Focusable="False" Height="52" Width="160" Cursor="Hand">
+                        <Button Grid.Column="1" Command="{Binding TogglePreviewCommand}" Focusable="False" Height="52" Width="132" Cursor="Hand" Margin="0,0,12,0" ToolTip="只关闭主页面预览，不影响录制">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource ModernBtn}">
+                                    <Setter Property="Background" Value="{DynamicResource AccentCyan}"/>
+                                    <Setter Property="FontWeight" Value="Black"/>
+                                    <Setter Property="FontSize" Value="18"/>
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="Button">
+                                                <Border Background="{TemplateBinding Background}" CornerRadius="8">
+                                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <Path Data="{StaticResource FluentVideoIcon}" Width="20" Height="20" Stretch="Uniform" Fill="White" Margin="0,0,8,0"/>
+                                                        <TextBlock x:Name="PreviewActionText" Text="预览开" Foreground="White" FontWeight="{TemplateBinding FontWeight}" FontSize="{TemplateBinding FontSize}"/>
+                                                    </StackPanel>
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <DataTrigger Binding="{Binding IsPreviewEnabled}" Value="False">
+                                                        <Setter TargetName="PreviewActionText" Property="Text" Value="预览关"/>
+                                                    </DataTrigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsPreviewEnabled}" Value="False">
+                                            <Setter Property="Background" Value="{DynamicResource TextSecondary}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+
+                        <Button Grid.Column="2" Command="{Binding ToggleRecordingCommand}" Focusable="False" Height="52" Width="160" Cursor="Hand">
                             <Button.Style>
                                 <Style TargetType="Button" BasedOn="{StaticResource ModernBtn}">
                                     <Setter Property="Background" Value="{DynamicResource AccentGreen}"/>
@@ -228,6 +261,25 @@
                                    Visibility="Collapsed"
                                    Opacity="1"
                                    RadiusX="2" RadiusY="2"/>
+                        <!-- 仅隐藏主页面预览，不停止摄像头采集或 FFmpeg 录制 -->
+                        <Grid IsHitTestVisible="False">
+                            <Grid.Style>
+                                <Style TargetType="Grid">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsPreviewEnabled}" Value="False">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Style>
+                            <Border Background="#DD1a1a2e" CornerRadius="10"/>
+                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <Path Data="{StaticResource FluentVideoIcon}" Width="52" Height="52" Stretch="Uniform" Fill="#AAFFFFFF" HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                                <TextBlock Text="预览已关闭" FontSize="22" FontWeight="Bold" Foreground="#AAFFFFFF" HorizontalAlignment="Center"/>
+                                <TextBlock Text="录制仍在后台继续" FontSize="14" Foreground="#66FFFFFF" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                            </StackPanel>
+                        </Grid>
                         <!-- 摄像头休眠提示 -->
                         <Grid IsHitTestVisible="False">
                             <Grid.Style>
@@ -541,5 +593,4 @@
         </Border>
     </Grid>
 </Window>
-
 

--- a/ExpressPackingMonitoring/SettingsWindow.xaml
+++ b/ExpressPackingMonitoring/SettingsWindow.xaml
@@ -1443,6 +1443,26 @@
                                                     Value="{Binding Config.MaxDurationMinutes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                                         </StackPanel>
                                     </Grid>
+                                    <Border Style="{StaticResource SectionDividerStyle}"/>
+
+                                    <Grid Style="{StaticResource SettingRowStyle}" Margin="0,0,0,14">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="24"/>
+                                            <ColumnDefinition Width="260"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Margin="0,0,16,0">
+                                            <TextBlock Text="开始停止同条码" Style="{StaticResource FieldLabelStyle}"/>
+                                            <TextBlock Text="录制中再次扫描同一单号才停止录像，扫描其他单号提醒但不停止录像"
+                                                       Style="{StaticResource FieldHintStyle}"/>
+                                        </StackPanel>
+                                        <CheckBox Grid.Column="2"
+                                                  IsChecked="{Binding Config.StartStopSameBarcode}"
+                                                  VerticalAlignment="Center"
+                                                  HorizontalAlignment="Left"
+                                                  Style="{StaticResource ToggleSwitchStyle}"/>
+                                    </Grid>
+                                    
 
                                     <Border Style="{StaticResource SectionDividerStyle}"/>
 
@@ -1699,6 +1719,8 @@
                                                     Value="{Binding Config.MinVideoFileSizeKB, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IntSliderValueConverter}}"/>
                                         </StackPanel>
                                     </Grid>
+
+                                    <Border Style="{StaticResource SectionDividerStyle}"/>
 
                                     <Grid Style="{StaticResource SettingRowStyle}" Margin="0">
                                         <Grid.ColumnDefinitions>


### PR DESCRIPTION
1. 主页面增加摄像头预览功能（关闭预览不影响录制）
<img width="1336" height="843" alt="image" src="https://github.com/user-attachments/assets/c5a2a6ff-adc3-4b62-a977-7348f842956d" />
<img width="1336" height="843" alt="image" src="https://github.com/user-attachments/assets/53521636-dfed-43e5-a98a-d4310234f7b8" />

2. 第一次扫描条码开始录像，第二次扫描停止录像（两次扫描的条码不一致 则提醒单号不一致 不停止录像）

<img width="906" height="753" alt="image" src="https://github.com/user-attachments/assets/39e30cbb-84a3-4ae0-86a0-a7121f223211" />
<img width="1336" height="843" alt="image" src="https://github.com/user-attachments/assets/2330f2ba-d503-47bc-8439-65ad04985730" />

