### PR TITLE
feat: 新增首次使用配置向导

### DIFF
--- a/ExpressPackingMonitoring/AppConfig.cs
+++ b/ExpressPackingMonitoring/AppConfig.cs
@@ -58,6 +58,7 @@ namespace ExpressPackingMonitoring.ViewModels
         // 工位用途："CameraMonitor"=摄像头监控工位，"PrintStation"=快递单打印工位，空值表示首次启动需要选择。
         public string WorkstationRole { get; set; } = "";
         public string PrintStationMonitorAddress { get; set; } = "";
+        public bool FirstUseWizardCompleted { get; set; } = false;
 
         // 核心：多磁盘配置列表
         public List<StorageLocation> StorageLocations { get; set; } = new() { new StorageLocation() };

--- a/ExpressPackingMonitoring/ExpressPackingMonitoring.csproj
+++ b/ExpressPackingMonitoring/ExpressPackingMonitoring.csproj
@@ -58,6 +58,7 @@
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.21" />
+    <PackageReference Include="ZXing.Net" Version="0.16.11" />
   </ItemGroup>
 
   <ItemGroup>
@@ -88,6 +89,7 @@
     <Compile Include="BarcodeHelper.cs" />
     <Compile Include="ConfirmDialog.xaml.cs" />
     <Compile Include="EncodingHelper.cs" />
+    <Compile Include="FirstUseSetupWizardWindow.xaml.cs" />
     <Compile Include="GlobalKeyboardHook.cs" />
     <Compile Include="MkvConversionResult.cs" />
     <Compile Include="RuntimeLog.cs" />

--- a/ExpressPackingMonitoring/FirstUseSetupWizardWindow.xaml
+++ b/ExpressPackingMonitoring/FirstUseSetupWizardWindow.xaml
@@ -1,0 +1,422 @@
+<Window x:Class="ExpressPackingMonitoring.FirstUseSetupWizardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="首次使用配置向导"
+        Height="690"
+        Width="920"
+        MinHeight="660"
+        MinWidth="860"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="app.ico"
+        Background="{DynamicResource WindowBackground}"
+        FontFamily="Microsoft YaHei UI, Segoe UI">
+    <Window.Resources>
+        <Style x:Key="WizardCardButtonStyle" TargetType="RadioButton">
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Margin" Value="0,0,0,12"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="RadioButton">
+                        <Border x:Name="Root"
+                                Padding="16"
+                                Background="{DynamicResource PanelBackground}"
+                                BorderBrush="{DynamicResource BorderDefault}"
+                                BorderThickness="1"
+                                CornerRadius="8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="22"/>
+                                    <ColumnDefinition Width="14"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid Width="18"
+                                      Height="18"
+                                      HorizontalAlignment="Left"
+                                      VerticalAlignment="Center">
+                                    <Ellipse x:Name="Outer"
+                                             Stroke="{DynamicResource BorderStrong}"
+                                             StrokeThickness="2"/>
+                                    <Ellipse x:Name="Inner"
+                                             Width="8"
+                                             Height="8"
+                                             Fill="{DynamicResource AccentBlue}"
+                                             HorizontalAlignment="Center"
+                                             VerticalAlignment="Center"
+                                             Opacity="0"/>
+                                </Grid>
+                                <ContentPresenter Grid.Column="2"
+                                                  VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Root" Property="BorderBrush" Value="{DynamicResource AccentBlue}"/>
+                                <Setter TargetName="Root" Property="Background" Value="{DynamicResource BorderLight}"/>
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Root" Property="BorderBrush" Value="{DynamicResource AccentBlue}"/>
+                                <Setter TargetName="Outer" Property="Stroke" Value="{DynamicResource AccentBlue}"/>
+                                <Setter TargetName="Inner" Property="Opacity" Value="1"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="WizardButtonStyle" TargetType="Button">
+            <Setter Property="Height" Value="38"/>
+            <Setter Property="MinWidth" Value="96"/>
+            <Setter Property="Padding" Value="16,0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderStrong}"/>
+            <Setter Property="Background" Value="{DynamicResource PanelBackground}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Root"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="8">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Root" Property="BorderBrush" Value="{DynamicResource AccentBlue}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Root" Property="Opacity" Value="0.55"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="PrimaryWizardButtonStyle" TargetType="Button" BasedOn="{StaticResource WizardButtonStyle}">
+            <Setter Property="Background" Value="{DynamicResource AccentBlue}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource AccentBlue}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+
+        <Style x:Key="StepTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+            <Setter Property="Margin" Value="0,0,0,14"/>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="32">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,22">
+            <TextBlock Text="首次使用配置向导"
+                       FontSize="28"
+                       FontWeight="Black"
+                       Foreground="{DynamicResource TextPrimary}"/>
+            <TextBlock Text="按最基础的步骤确认打包模式、摄像头、麦克风和扫码枪。"
+                       Margin="0,8,0,0"
+                       FontSize="14"
+                       Foreground="{DynamicResource TextSecondary}"/>
+        </StackPanel>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="190"/>
+                <ColumnDefinition Width="24"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    Background="{DynamicResource ControlBackground}"
+                    BorderBrush="{DynamicResource BorderLight}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="18">
+                <StackPanel>
+                    <TextBlock x:Name="StepModeText" Text="1. 选择打包模式" Style="{StaticResource StepTextStyle}"/>
+                    <TextBlock x:Name="StepCameraText" Text="2. 选择摄像头" Style="{StaticResource StepTextStyle}"/>
+                    <TextBlock x:Name="StepMicText" Text="3. 选择麦克风" Style="{StaticResource StepTextStyle}"/>
+                    <TextBlock x:Name="StepScannerText" Text="4. 测试扫码枪" Style="{StaticResource StepTextStyle}"/>
+                    <TextBlock x:Name="StepDoneText" Text="5. 完成" Style="{StaticResource StepTextStyle}"/>
+                </StackPanel>
+            </Border>
+
+            <Border Grid.Column="2"
+                    Background="{DynamicResource PanelBackground}"
+                    BorderBrush="{DynamicResource BorderLight}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="24">
+                <Grid>
+                    <Grid x:Name="ModePage">
+                        <StackPanel>
+                            <TextBlock Text="选择打包模式"
+                                       FontSize="22"
+                                       FontWeight="Black"
+                                       Foreground="{DynamicResource TextPrimary}"/>
+                            <TextBlock Text="推荐连续打包模式，扫码下一单时自动保存上一单。"
+                                       Margin="0,8,0,22"
+                                       FontSize="14"
+                                       Foreground="{DynamicResource TextSecondary}"/>
+                            <RadioButton x:Name="ContinuousModeRadio"
+                                         GroupName="PackingMode"
+                                         IsChecked="True"
+                                         Style="{StaticResource WizardCardButtonStyle}">
+                                <StackPanel>
+                                    <DockPanel LastChildFill="False">
+                                        <TextBlock Text="连续打包模式"
+                                                   FontSize="18"
+                                                   FontWeight="Black"
+                                                   Foreground="{DynamicResource TextPrimary}"/>
+                                        <Border Margin="10,0,0,0"
+                                                Padding="8,3"
+                                                Background="{DynamicResource AccentBlue}"
+                                                CornerRadius="6">
+                                            <TextBlock Text="推荐" Foreground="White" FontSize="12" FontWeight="Bold"/>
+                                        </Border>
+                                    </DockPanel>
+                                    <TextBlock Text="扫描新单号后，自动结束上一单并开始下一单。"
+                                               Margin="0,7,0,0"
+                                               FontSize="14"
+                                               TextWrapping="Wrap"
+                                               Foreground="{DynamicResource TextSecondary}"/>
+                                </StackPanel>
+                            </RadioButton>
+                            <RadioButton x:Name="SameCodeModeRadio"
+                                         GroupName="PackingMode"
+                                         Style="{StaticResource WizardCardButtonStyle}">
+                                <StackPanel>
+                                    <TextBlock Text="同码停录模式"
+                                               FontSize="18"
+                                               FontWeight="Black"
+                                               Foreground="{DynamicResource TextPrimary}"/>
+                                    <TextBlock Text="扫描单号开始录制，再次扫描同一单号停止录制。"
+                                               Margin="0,7,0,0"
+                                               FontSize="14"
+                                               TextWrapping="Wrap"
+                                               Foreground="{DynamicResource TextSecondary}"/>
+                                </StackPanel>
+                            </RadioButton>
+                        </StackPanel>
+                    </Grid>
+
+                    <Grid x:Name="CameraPage" Visibility="Collapsed">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel>
+                            <TextBlock Text="选择摄像头"
+                                       FontSize="22"
+                                       FontWeight="Black"
+                                       Foreground="{DynamicResource TextPrimary}"/>
+                            <TextBlock Text="能看到实时画面，就说明摄像头基础配置正常。"
+                                       Margin="0,8,0,20"
+                                       FontSize="14"
+                                       Foreground="{DynamicResource TextSecondary}"/>
+                        </StackPanel>
+                        <ComboBox x:Name="CameraComboBox"
+                                  Grid.Row="1"
+                                  Height="38"
+                                  DisplayMemberPath="Name"
+                                  SelectionChanged="CameraComboBox_SelectionChanged"
+                                  Margin="0,0,0,16"/>
+                        <Border Grid.Row="2"
+                                Background="Black"
+                                BorderBrush="{DynamicResource BorderDefault}"
+                                BorderThickness="1"
+                                CornerRadius="8"
+                                ClipToBounds="True">
+                            <Grid>
+                                <Image x:Name="CameraPreviewImage"
+                                       Stretch="Uniform"/>
+                                <TextBlock x:Name="CameraStatusText"
+                                           Text="正在准备摄像头预览..."
+                                           Foreground="#DDFFFFFF"
+                                           Background="#66000000"
+                                           Padding="10,6"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           TextWrapping="Wrap"/>
+                            </Grid>
+                        </Border>
+                    </Grid>
+
+                    <Grid x:Name="MicPage" Visibility="Collapsed">
+                        <StackPanel>
+                            <TextBlock Text="选择麦克风"
+                                       FontSize="22"
+                                       FontWeight="Black"
+                                       Foreground="{DynamicResource TextPrimary}"/>
+                            <TextBlock Text="说话时音量条有跳动，就说明麦克风基础配置正常。"
+                                       Margin="0,8,0,20"
+                                       FontSize="14"
+                                       Foreground="{DynamicResource TextSecondary}"/>
+                            <ComboBox x:Name="MicComboBox"
+                                      Height="38"
+                                      DisplayMemberPath="Name"
+                                      SelectionChanged="MicComboBox_SelectionChanged"
+                                      Margin="0,0,0,24"/>
+                            <Border Background="{DynamicResource ControlBackground}"
+                                    BorderBrush="{DynamicResource BorderDefault}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="18">
+                                <StackPanel>
+                                    <TextBlock Text="实时音量"
+                                               FontSize="16"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource TextPrimary}"
+                                               Margin="0,0,0,12"/>
+                                    <ProgressBar x:Name="MicLevelBar"
+                                                 Height="18"
+                                                 Minimum="0"
+                                                 Maximum="100"
+                                                 Foreground="{DynamicResource AccentBlue}"
+                                                 Background="{DynamicResource BorderStrong}"/>
+                                    <TextBlock x:Name="MicStatusText"
+                                               Text="正在准备麦克风..."
+                                               Margin="0,12,0,0"
+                                               FontSize="13"
+                                               Foreground="{DynamicResource TextSecondary}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+
+                    <Grid x:Name="ScannerPage" Visibility="Collapsed">
+                        <StackPanel>
+                            <TextBlock Text="测试扫码枪"
+                                       FontSize="22"
+                                       FontWeight="Black"
+                                       Foreground="{DynamicResource TextPrimary}"/>
+                            <TextBlock Text="请用扫码枪扫描一个快递面单条码。"
+                                       Margin="0,8,0,18"
+                                       FontSize="14"
+                                       Foreground="{DynamicResource TextSecondary}"/>
+                            <Border Background="{DynamicResource ControlBackground}"
+                                    BorderBrush="{DynamicResource BorderDefault}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="10"
+                                    Margin="0,0,0,12">
+                                <StackPanel HorizontalAlignment="Center">
+                                    <Image x:Name="TestBarcodeImage"
+                                           Width="430"
+                                           Height="88"
+                                           Stretch="Uniform"/>
+                                    <TextBlock x:Name="TestBarcodeText"
+                                               Margin="0,6,0,0"
+                                               FontSize="12"
+                                               HorizontalAlignment="Center"
+                                               Foreground="{DynamicResource TextSecondary}"/>
+                                </StackPanel>
+                            </Border>
+                            <TextBox x:Name="ScanTestTextBox"
+                                     Height="38"
+                                     FontSize="16"
+                                     Padding="10,0"
+                                     VerticalContentAlignment="Center"
+                                     PreviewKeyDown="ScanTestTextBox_PreviewKeyDown"
+                                     TextChanged="ScanTestTextBox_TextChanged"/>
+                            <Border Margin="0,12,0,0"
+                                    Background="{DynamicResource ControlBackground}"
+                                    BorderBrush="{DynamicResource BorderDefault}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    MinHeight="138"
+                                    Padding="14">
+                                <TextBlock x:Name="ScanStatusText"
+                                           Text="等待扫码内容..."
+                                           FontSize="13"
+                                           LineHeight="20"
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource TextSecondary}"/>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+
+                    <Grid x:Name="DonePage" Visibility="Collapsed">
+                        <StackPanel>
+                            <TextBlock Text="配置完成"
+                                       FontSize="22"
+                                       FontWeight="Black"
+                                       Foreground="{DynamicResource TextPrimary}"/>
+                            <TextBlock Text="下面是日常打包流程。"
+                                       Margin="0,8,0,20"
+                                       FontSize="14"
+                                       Foreground="{DynamicResource TextSecondary}"/>
+                            <Border Background="{DynamicResource ControlBackground}"
+                                    BorderBrush="{DynamicResource BorderDefault}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="18">
+                                <TextBlock x:Name="FlowText"
+                                           FontSize="16"
+                                           LineHeight="30"
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource TextPrimary}"/>
+                            </Border>
+                            <Border Margin="0,14,0,0"
+                                    Background="{DynamicResource ControlBackground}"
+                                    BorderBrush="{DynamicResource BorderDefault}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="16">
+                                <StackPanel>
+                                    <TextBlock Text="局域网查看视频"
+                                               FontSize="15"
+                                               FontWeight="Bold"
+                                               Foreground="{DynamicResource TextPrimary}"/>
+                                    <TextBlock Text="同一局域网内的电脑、手机等设备，可以通过主界面底部显示的局域网访问地址，打开打包视频和回放页面。请确认这些设备连接在同一个局域网内。"
+                                               Margin="0,7,0,0"
+                                               FontSize="13"
+                                               LineHeight="20"
+                                               TextWrapping="Wrap"
+                                               Foreground="{DynamicResource TextSecondary}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2"
+                Margin="0,22,0,0"
+                BorderBrush="{DynamicResource BorderLight}"
+                BorderThickness="0,1,0,0"
+                Padding="0,16,0,0">
+            <Grid>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                    <Button Content="跳过"
+                            Style="{StaticResource WizardButtonStyle}"
+                            Click="SkipButton_Click"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button x:Name="BackButton"
+                            Content="上一步"
+                            Style="{StaticResource WizardButtonStyle}"
+                            Margin="0,0,10,0"
+                            Click="BackButton_Click"/>
+                    <Button x:Name="NextButton"
+                            Content="下一步"
+                            Style="{StaticResource PrimaryWizardButtonStyle}"
+                            Click="NextButton_Click"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/ExpressPackingMonitoring/FirstUseSetupWizardWindow.xaml.cs
+++ b/ExpressPackingMonitoring/FirstUseSetupWizardWindow.xaml.cs
@@ -1,0 +1,548 @@
+#nullable disable
+using AForge.Video;
+using AForge.Video.DirectShow;
+using ExpressPackingMonitoring.ViewModels;
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using ZXing;
+using ZXing.Common;
+
+namespace ExpressPackingMonitoring;
+
+public partial class FirstUseSetupWizardWindow : Window
+{
+    private readonly AppConfig _config;
+    private readonly List<TextBlock> _stepTexts;
+    private int _stepIndex;
+    private bool _isLoadingDevices;
+    private VideoCaptureDevice _previewCamera;
+    private DateTime _lastPreviewUpdateAt = DateTime.MinValue;
+    private WasapiCapture _micCapture;
+    private readonly string _testBarcodeValue = $"TEST{DateTime.Now:yyyyMMddHHmmss}";
+
+    public bool WasSkipped { get; private set; }
+    public AppConfig ResultConfig => _config;
+
+    public FirstUseSetupWizardWindow(AppConfig config)
+    {
+        InitializeComponent();
+        _config = config;
+        _stepTexts = new List<TextBlock> { StepModeText, StepCameraText, StepMicText, StepScannerText, StepDoneText };
+
+        ContinuousModeRadio.IsChecked = !_config.EnableSameBarcodeStopRecording;
+        SameCodeModeRadio.IsChecked = _config.EnableSameBarcodeStopRecording;
+        RenderTestBarcode();
+
+        Loaded += FirstUseSetupWizardWindow_Loaded;
+        Closed += FirstUseSetupWizardWindow_Closed;
+        ShowStep(0);
+    }
+
+    private void RenderTestBarcode()
+    {
+        var writer = new BarcodeWriterPixelData
+        {
+            Format = BarcodeFormat.CODE_128,
+            Options = new EncodingOptions
+            {
+                Width = 430,
+                Height = 120,
+                Margin = 12,
+                PureBarcode = false
+            }
+        };
+
+        var pixelData = writer.Write(_testBarcodeValue);
+        var source = BitmapSource.Create(
+            pixelData.Width,
+            pixelData.Height,
+            96,
+            96,
+            PixelFormats.Bgra32,
+            null,
+            pixelData.Pixels,
+            pixelData.Width * 4);
+        source.Freeze();
+
+        TestBarcodeImage.Source = source;
+        TestBarcodeText.Text = $"屏幕测试条码：{_testBarcodeValue}，也可以扫描任意真实面单条码。";
+    }
+
+    private async void FirstUseSetupWizardWindow_Loaded(object sender, RoutedEventArgs e)
+    {
+        _isLoadingDevices = true;
+        try
+        {
+            await LoadDevicesAsync();
+        }
+        finally
+        {
+            _isLoadingDevices = false;
+        }
+    }
+
+    private async Task LoadDevicesAsync()
+    {
+        var result = await RunOnStaThread(() =>
+        {
+            var cameras = new List<CameraInfo>();
+            var mics = new List<MicInfo>();
+
+            try
+            {
+                var videoDevices = new FilterInfoCollection(FilterCategory.VideoInputDevice);
+                for (int i = 0; i < videoDevices.Count; i++)
+                {
+                    cameras.Add(new CameraInfo
+                    {
+                        Index = i,
+                        Name = $"[{i}] {videoDevices[i].Name}",
+                        Moniker = videoDevices[i].MonikerString
+                    });
+                }
+            }
+            catch { }
+
+            try
+            {
+                using var enumerator = new MMDeviceEnumerator();
+                var audioDevices = enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+                foreach (var device in audioDevices)
+                {
+                    mics.Add(new MicInfo { Name = device.FriendlyName, Moniker = device.ID });
+                }
+            }
+            catch { }
+
+            return (Cameras: cameras, Mics: mics);
+        });
+
+        var cameras = result.Cameras;
+        if (cameras.Count == 0)
+        {
+            cameras.Add(new CameraInfo { Index = 0, Name = "[0] 未检测到摄像头", Moniker = "" });
+        }
+
+        CameraComboBox.ItemsSource = cameras;
+        CameraComboBox.SelectedItem = cameras.FirstOrDefault(c => !string.IsNullOrEmpty(_config.CameraMonikerString) && c.Moniker == _config.CameraMonikerString)
+            ?? cameras.FirstOrDefault(c => c.Index == _config.CameraIndex)
+            ?? cameras.FirstOrDefault();
+
+        var mics = result.Mics;
+        if (mics.Count == 0)
+        {
+            mics.Add(new MicInfo { Name = "未检测到麦克风", Moniker = "" });
+        }
+
+        MicComboBox.ItemsSource = mics;
+        MicComboBox.SelectedItem = mics.FirstOrDefault(m => !string.IsNullOrEmpty(_config.AudioDeviceMoniker) && m.Moniker == _config.AudioDeviceMoniker)
+            ?? mics.FirstOrDefault(m => m.Name == _config.AudioDeviceName)
+            ?? mics.FirstOrDefault(IsAvailableMic)
+            ?? mics.FirstOrDefault();
+    }
+
+    private static Task<T> RunOnStaThread<T>(Func<T> func)
+    {
+        var tcs = new TaskCompletionSource<T>();
+        var thread = new Thread(() =>
+        {
+            try { tcs.SetResult(func()); }
+            catch (Exception ex) { tcs.SetException(ex); }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.IsBackground = true;
+        thread.Start();
+        return tcs.Task;
+    }
+
+    private void ShowStep(int stepIndex)
+    {
+        _stepIndex = Math.Clamp(stepIndex, 0, 4);
+        ModePage.Visibility = _stepIndex == 0 ? Visibility.Visible : Visibility.Collapsed;
+        CameraPage.Visibility = _stepIndex == 1 ? Visibility.Visible : Visibility.Collapsed;
+        MicPage.Visibility = _stepIndex == 2 ? Visibility.Visible : Visibility.Collapsed;
+        ScannerPage.Visibility = _stepIndex == 3 ? Visibility.Visible : Visibility.Collapsed;
+        DonePage.Visibility = _stepIndex == 4 ? Visibility.Visible : Visibility.Collapsed;
+
+        for (int i = 0; i < _stepTexts.Count; i++)
+        {
+            _stepTexts[i].Foreground = i == _stepIndex
+                ? (System.Windows.Media.Brush)FindResource("AccentBlue")
+                : (System.Windows.Media.Brush)FindResource("TextSecondary");
+            _stepTexts[i].FontWeight = i == _stepIndex ? FontWeights.Black : FontWeights.SemiBold;
+        }
+
+        BackButton.IsEnabled = _stepIndex > 0;
+        NextButton.Content = _stepIndex == 4 ? "完成" : "下一步";
+
+        if (_stepIndex == 1)
+        {
+            StartCameraPreviewFromSelection();
+        }
+        else
+        {
+            StopCameraPreview();
+        }
+
+        if (_stepIndex == 2)
+        {
+            StartMicPreviewFromSelection();
+        }
+        else
+        {
+            StopMicPreview();
+        }
+
+        if (_stepIndex == 3)
+        {
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                ScanTestTextBox.Focus();
+                ScanTestTextBox.SelectAll();
+            }));
+        }
+
+        if (_stepIndex == 4)
+        {
+            UpdateFlowText();
+        }
+    }
+
+    private void NextButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_stepIndex == 4)
+        {
+            ApplySelections();
+            WasSkipped = false;
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        ShowStep(_stepIndex + 1);
+    }
+
+    private void BackButton_Click(object sender, RoutedEventArgs e)
+    {
+        ShowStep(_stepIndex - 1);
+    }
+
+    private void SkipButton_Click(object sender, RoutedEventArgs e)
+    {
+        WasSkipped = true;
+        DialogResult = true;
+        Close();
+    }
+
+    private void CameraComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoadingDevices) return;
+        if (_stepIndex == 1)
+        {
+            StartCameraPreviewFromSelection();
+        }
+    }
+
+    private void StartCameraPreviewFromSelection()
+    {
+        StopCameraPreview();
+        CameraPreviewImage.Source = null;
+
+        if (CameraComboBox.SelectedItem is not CameraInfo camera || string.IsNullOrEmpty(camera.Moniker))
+        {
+            CameraStatusText.Text = "未检测到可用摄像头";
+            CameraStatusText.Visibility = Visibility.Visible;
+            return;
+        }
+
+        try
+        {
+            _previewCamera = new VideoCaptureDevice(camera.Moniker);
+            if (_previewCamera.VideoCapabilities.Length > 0)
+            {
+                _previewCamera.VideoResolution = SelectBestCapability(_previewCamera.VideoCapabilities);
+            }
+
+            _previewCamera.NewFrame += PreviewCamera_NewFrame;
+            _previewCamera.Start();
+            CameraStatusText.Text = "正在等待摄像头画面...";
+            CameraStatusText.Visibility = Visibility.Visible;
+        }
+        catch (Exception ex)
+        {
+            CameraStatusText.Text = $"摄像头预览启动失败：{ex.Message}";
+            CameraStatusText.Visibility = Visibility.Visible;
+            StopCameraPreview();
+        }
+    }
+
+    private VideoCapabilities SelectBestCapability(VideoCapabilities[] capabilities)
+    {
+        var best = capabilities[0];
+        int bestScore = int.MaxValue;
+        foreach (var capability in capabilities)
+        {
+            int resDiff = Math.Abs(capability.FrameSize.Width - _config.FrameWidth) + Math.Abs(capability.FrameSize.Height - _config.FrameHeight);
+            int fpsDiff = Math.Abs(capability.AverageFrameRate - _config.Fps);
+            int score = resDiff * 10 + fpsDiff;
+            if (score < bestScore)
+            {
+                bestScore = score;
+                best = capability;
+            }
+        }
+
+        return best;
+    }
+
+    private void PreviewCamera_NewFrame(object sender, NewFrameEventArgs eventArgs)
+    {
+        if (DateTime.UtcNow - _lastPreviewUpdateAt < TimeSpan.FromMilliseconds(100)) return;
+        _lastPreviewUpdateAt = DateTime.UtcNow;
+
+        try
+        {
+            using var bitmap = (Bitmap)eventArgs.Frame.Clone();
+            BitmapSource source = ConvertBitmapToSource(bitmap);
+            source.Freeze();
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                CameraPreviewImage.Source = source;
+                CameraStatusText.Visibility = Visibility.Collapsed;
+            }));
+        }
+        catch { }
+    }
+
+    private static BitmapSource ConvertBitmapToSource(Bitmap bitmap)
+    {
+        using var stream = new MemoryStream();
+        bitmap.Save(stream, ImageFormat.Bmp);
+        stream.Position = 0;
+        var source = BitmapFrame.Create(stream, BitmapCreateOptions.None, BitmapCacheOption.OnLoad);
+        return source;
+    }
+
+    private void StopCameraPreview()
+    {
+        if (_previewCamera == null) return;
+
+        try { _previewCamera.NewFrame -= PreviewCamera_NewFrame; } catch { }
+        try
+        {
+            if (_previewCamera.IsRunning)
+            {
+                _previewCamera.SignalToStop();
+                for (int i = 0; i < 20 && _previewCamera.IsRunning; i++)
+                {
+                    Thread.Sleep(50);
+                }
+            }
+        }
+        catch { }
+        _previewCamera = null;
+    }
+
+    private void MicComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoadingDevices) return;
+        if (_stepIndex == 2)
+        {
+            StartMicPreviewFromSelection();
+        }
+    }
+
+    private void StartMicPreviewFromSelection()
+    {
+        StopMicPreview();
+        MicLevelBar.Value = 0;
+
+        if (MicComboBox.SelectedItem is not MicInfo mic || !IsAvailableMic(mic))
+        {
+            MicStatusText.Text = "未检测到可用麦克风";
+            return;
+        }
+
+        try
+        {
+            using var enumerator = new MMDeviceEnumerator();
+            var device = !string.IsNullOrEmpty(mic.Moniker)
+                ? enumerator.GetDevice(mic.Moniker)
+                : enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+            _micCapture = new WasapiCapture(device);
+            _micCapture.DataAvailable += MicCapture_DataAvailable;
+            _micCapture.RecordingStopped += (_, __) => Dispatcher.BeginInvoke(new Action(() => MicLevelBar.Value = 0));
+            _micCapture.StartRecording();
+            MicStatusText.Text = "请对着麦克风说话，观察音量条";
+        }
+        catch (Exception ex)
+        {
+            MicStatusText.Text = $"麦克风启动失败：{ex.Message}";
+            StopMicPreview();
+        }
+    }
+
+    private void MicCapture_DataAvailable(object sender, WaveInEventArgs e)
+    {
+        double peak = CalculatePeak(e.Buffer, e.BytesRecorded, _micCapture.WaveFormat);
+        double value = Math.Clamp(peak * 140.0, 0, 100);
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            MicLevelBar.Value = value;
+            if (value > 8)
+            {
+                MicStatusText.Text = "已检测到麦克风音量";
+            }
+        }));
+    }
+
+    private static double CalculatePeak(byte[] buffer, int bytesRecorded, WaveFormat format)
+    {
+        double peak = 0;
+        if (format.Encoding == WaveFormatEncoding.IeeeFloat && format.BitsPerSample == 32)
+        {
+            for (int i = 0; i + 4 <= bytesRecorded; i += 4)
+            {
+                peak = Math.Max(peak, Math.Abs(BitConverter.ToSingle(buffer, i)));
+            }
+        }
+        else if (format.BitsPerSample == 16)
+        {
+            for (int i = 0; i + 2 <= bytesRecorded; i += 2)
+            {
+                peak = Math.Max(peak, Math.Abs(BitConverter.ToInt16(buffer, i) / 32768.0));
+            }
+        }
+        else if (format.BitsPerSample == 24)
+        {
+            for (int i = 0; i + 3 <= bytesRecorded; i += 3)
+            {
+                int sample = (buffer[i + 2] << 24) | (buffer[i + 1] << 16) | (buffer[i] << 8);
+                peak = Math.Max(peak, Math.Abs(sample / 2147483648.0));
+            }
+        }
+        else if (format.BitsPerSample == 32)
+        {
+            for (int i = 0; i + 4 <= bytesRecorded; i += 4)
+            {
+                peak = Math.Max(peak, Math.Abs(BitConverter.ToInt32(buffer, i) / 2147483648.0));
+            }
+        }
+
+        return peak;
+    }
+
+    private void StopMicPreview()
+    {
+        if (_micCapture == null) return;
+
+        try { _micCapture.DataAvailable -= MicCapture_DataAvailable; } catch { }
+        try { _micCapture.StopRecording(); } catch { }
+        _micCapture.Dispose();
+        _micCapture = null;
+    }
+
+    private void ScanTestTextBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_stepIndex != 3) return;
+        string content = ScanTestTextBox.Text.Trim();
+        if (string.IsNullOrEmpty(content))
+        {
+            ScanStatusText.Text = "等待扫码内容...";
+            ScanStatusText.Foreground = (System.Windows.Media.Brush)FindResource("TextSecondary");
+            return;
+        }
+
+        ScanStatusText.Text =
+            "没有检测到回车/换行结束符\n" +
+            "请将扫码枪设置为“扫描后自动回车/换行”，否则软件可能无法自动开始录制\n" +
+            "可联系扫码枪卖家：如何开启“扫描后自动回车 / Enter 后缀”";
+        ScanStatusText.Foreground = (System.Windows.Media.Brush)FindResource("TextPrimary");
+    }
+
+    private void ScanTestTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter || e.Key == Key.Return)
+        {
+            ScanStatusText.Text = "扫码枪测试通过";
+            ScanStatusText.Foreground = (System.Windows.Media.Brush)FindResource("AccentBlue");
+            e.Handled = true;
+        }
+    }
+
+    private void UpdateFlowText()
+    {
+        if (SameCodeModeRadio.IsChecked == true)
+        {
+            FlowText.Text =
+                "1. 扫描面单条码开始录制\n" +
+                "2. 打包完成后再次扫描同一单号\n" +
+                "3. 软件停止录制并保存视频";
+        }
+        else
+        {
+            FlowText.Text =
+                "1. 放好快递\n" +
+                "2. 扫描面单条码开始录制\n" +
+                "3. 打包完成后扫描下一单\n" +
+                "4. 软件自动保存上一单并开始下一单";
+        }
+    }
+
+    private void ApplySelections()
+    {
+        _config.EnableSameBarcodeStopRecording = SameCodeModeRadio.IsChecked == true;
+        _config.EnableAudioRecording = true;
+
+        if (CameraComboBox.SelectedItem is CameraInfo camera && !string.IsNullOrEmpty(camera.Moniker))
+        {
+            _config.CameraIndex = camera.Index;
+            _config.CameraMonikerString = camera.Moniker;
+        }
+
+        if (MicComboBox.SelectedItem is MicInfo mic && IsAvailableMic(mic))
+        {
+            _config.AudioDeviceName = mic.Name;
+            _config.AudioDeviceMoniker = mic.Moniker ?? "";
+        }
+
+        if (!string.IsNullOrEmpty(_config.CameraMonikerString))
+        {
+            _config.CameraConfigs[_config.CameraMonikerString] = new CameraSettings
+            {
+                FrameWidth = _config.FrameWidth,
+                FrameHeight = _config.FrameHeight,
+                Fps = _config.Fps,
+                AudioDeviceName = _config.AudioDeviceName,
+                AudioDeviceMoniker = _config.AudioDeviceMoniker,
+                AudioSyncOffsetMs = _config.AudioSyncOffsetMs
+            };
+        }
+    }
+
+    private static bool IsAvailableMic(MicInfo mic)
+    {
+        return mic != null
+            && !string.IsNullOrWhiteSpace(mic.Name)
+            && mic.Name != "未检测到麦克风";
+    }
+
+    private void FirstUseSetupWizardWindow_Closed(object sender, EventArgs e)
+    {
+        StopCameraPreview();
+        StopMicPreview();
+    }
+}

--- a/ExpressPackingMonitoring/MainViewModel.cs
+++ b/ExpressPackingMonitoring/MainViewModel.cs
@@ -859,6 +859,7 @@ namespace ExpressPackingMonitoring.ViewModels
                 if (settingsAccepted) {
                     // 判断摄像头相关配置是否变更
                     bool cameraChanged = Config.CameraIndex != clonedConfig.CameraIndex
+                        || Config.CameraMonikerString != clonedConfig.CameraMonikerString
                         || Config.FrameWidth != clonedConfig.FrameWidth
                         || Config.FrameHeight != clonedConfig.FrameHeight
                         || Config.Fps != clonedConfig.Fps;
@@ -930,6 +931,80 @@ namespace ExpressPackingMonitoring.ViewModels
                 }
             }
             catch (Exception ex) { ShowToast($"设置错误: {ex.Message}"); }
+        }
+
+        public void RunFirstUseSetupWizardIfNeeded(System.Windows.Window owner)
+        {
+            if (Config.FirstUseWizardCompleted || _isDisposed)
+                return;
+
+            bool pausedCamera = false;
+            try
+            {
+                if (!IsRecording)
+                {
+                    StopCamera();
+                    pausedCamera = true;
+                }
+
+                var clonedConfig = JsonSerializer.Deserialize<AppConfig>(JsonSerializer.Serialize(Config)) ?? new AppConfig();
+                var wizard = new FirstUseSetupWizardWindow(clonedConfig) { Owner = owner };
+                MainWindow setupOwner = owner as MainWindow;
+                setupOwner?.SuspendCapsLockForModalWindow();
+
+                bool accepted;
+                try
+                {
+                    accepted = wizard.ShowDialog() == true;
+                }
+                finally
+                {
+                    setupOwner?.ResumeCapsLockAfterModalWindow();
+                }
+
+                if (!accepted)
+                    return;
+
+                if (!wizard.WasSkipped)
+                {
+                    Config = wizard.ResultConfig;
+                }
+
+                Config.FirstUseWizardCompleted = true;
+                SaveConfig();
+                ShowToast(wizard.WasSkipped ? "已跳过配置向导" : "配置向导已完成");
+            }
+            catch (Exception ex)
+            {
+                RuntimeLog.Error("SetupWizard", "First-use setup wizard failed", ex);
+                ShowToast($"配置向导错误: {ex.Message}");
+            }
+            finally
+            {
+                if (pausedCamera && !IsRecording && !_isDisposed)
+                {
+                    _consecutiveRestartFailures = 0;
+                    RestartCamera();
+                }
+            }
+        }
+
+        public bool SuspendCameraForSetupWizard()
+        {
+            if (IsRecording || _isDisposed)
+                return false;
+
+            StopCamera();
+            return true;
+        }
+
+        public void ResumeCameraAfterSetupWizard()
+        {
+            if (IsRecording || _isDisposed)
+                return;
+
+            _consecutiveRestartFailures = 0;
+            RestartCamera();
         }
 
         private void OpenStatsWindow()

--- a/ExpressPackingMonitoring/MainWindow.xaml.cs
+++ b/ExpressPackingMonitoring/MainWindow.xaml.cs
@@ -175,6 +175,11 @@ namespace ExpressPackingMonitoring
                 {
                     this.Title = "打包监控";
                 }
+
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    (DataContext as MainViewModel)?.RunFirstUseSetupWizardIfNeeded(this);
+                }), DispatcherPriority.ContextIdle);
             };
             SourceInitialized += (_, __) =>
             {

--- a/ExpressPackingMonitoring/SettingsWindow.xaml
+++ b/ExpressPackingMonitoring/SettingsWindow.xaml
@@ -935,6 +935,26 @@
                                             <ColumnDefinition Width="260"/>
                                         </Grid.ColumnDefinitions>
                                         <StackPanel Margin="0,0,16,0">
+                                            <TextBlock Text="配置向导" Style="{StaticResource FieldLabelStyle}"/>
+                                            <TextBlock Text="重新检查打包模式、摄像头、麦克风和扫码枪"
+                                                       Style="{StaticResource FieldHintStyle}"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2"
+                                                Content="重新运行配置向导"
+                                                Click="RunSetupWizard_Click"
+                                                Style="{StaticResource SecondaryActionButtonStyle}"
+                                                Height="32"
+                                                Padding="12,0"
+                                                HorizontalAlignment="Left"/>
+                                    </Grid>
+
+                                    <Grid Style="{StaticResource SettingRowStyle}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="24"/>
+                                            <ColumnDefinition Width="260"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Margin="0,0,16,0">
                                             <TextBlock Text="外观主题" Style="{StaticResource FieldLabelStyle}"/>
                                             <TextBlock Text="可跟随系统，或固定为浅色 / 深色主题"
                                                        Style="{StaticResource FieldHintStyle}"/>

--- a/ExpressPackingMonitoring/SettingsWindow.xaml.cs
+++ b/ExpressPackingMonitoring/SettingsWindow.xaml.cs
@@ -640,6 +640,39 @@ namespace ExpressPackingMonitoring
             this.Close();
         }
 
+        private async void RunSetupWizard_Click(object sender, RoutedEventArgs e)
+        {
+            Keyboard.ClearFocus();
+            SyncSelectedMicToConfig();
+
+            bool pausedCamera = false;
+            try
+            {
+                if (!_isRecording)
+                    pausedCamera = MainVM.SuspendCameraForSetupWizard();
+
+                var wizard = new FirstUseSetupWizardWindow(Config) { Owner = this };
+                if (wizard.ShowDialog() == true && !wizard.WasSkipped)
+                {
+                    Config.FirstUseWizardCompleted = true;
+                    _isLoadingDevices = true;
+                    try
+                    {
+                        await LoadAllDevicesAsync();
+                    }
+                    finally
+                    {
+                        _isLoadingDevices = false;
+                    }
+                }
+            }
+            finally
+            {
+                if (pausedCamera)
+                    MainVM.ResumeCameraAfterSetupWizard();
+            }
+        }
+
         private void ZoomScaleSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (MainVM != null)


### PR DESCRIPTION
新增首次使用配置向导，覆盖打包模式、摄像头预览、麦克风音量和扫码枪回车检测

首次进入摄像头监控工位时自动弹出向导，设置页增加重新运行入口；完成后保存基础配置，跳过则只标记向导已处理

扫码枪测试页提供屏幕测试条码，也支持扫描真实快递面单条码

<img width="906" height="683" alt="image" src="https://github.com/user-attachments/assets/33c4ac00-2aa2-4faa-b9da-96072ee931f3" />

