### PR TITLE
feat: 受保护主机的查看端申请连接与网页访问

### DIFF
--- a/ExpressPackingMonitoring.Tests/BackupCompatibilityPolicyTests.cs
+++ b/ExpressPackingMonitoring.Tests/BackupCompatibilityPolicyTests.cs
@@ -66,4 +66,32 @@ public sealed class BackupCompatibilityPolicyTests
         Assert.Null(BackupCompatibilityPolicy.ValidateClient(mobile));
         Assert.Null(BackupCompatibilityPolicy.ValidateClient(workstation));
     }
+
+    [Fact]
+    public void ViewerClientUsesItsOwnProtocolFloor()
+    {
+        var valid = new BackupDeviceEnrollmentRequest
+        {
+            DeviceKind = "viewer",
+            ClientVersion = BackupCompatibilityPolicy.MinimumViewerVersion,
+            ClientBuildNumber = 0,
+            BackupProtocol = "mobile-backup-v2",
+            EnrollmentVersion = 2,
+            AuthVersion = 3
+        };
+        var outdated = new BackupDeviceEnrollmentRequest
+        {
+            DeviceKind = "viewer",
+            ClientVersion = "0.0.48",
+            ClientBuildNumber = 0,
+            BackupProtocol = "mobile-backup-v2",
+            EnrollmentVersion = 2,
+            AuthVersion = 3
+        };
+
+        Assert.Null(BackupCompatibilityPolicy.ValidateClient(valid));
+        BackupCompatibilityFailure? failure = BackupCompatibilityPolicy.ValidateClient(outdated);
+        Assert.NotNull(failure);
+        Assert.Equal("viewer", failure.UpdateTarget);
+    }
 }

--- a/ExpressPackingMonitoring.Tests/ViewerWebAccessClientTests.cs
+++ b/ExpressPackingMonitoring.Tests/ViewerWebAccessClientTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Net.Sockets;
+using ExpressPackingMonitoring.Config;
+using ExpressPackingMonitoring.Data;
+using ExpressPackingMonitoring.Services;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace ExpressPackingMonitoring.Tests;
+
+[Collection("Web server tests")]
+public sealed class ViewerWebAccessClientTests
+{
+    [Theory]
+    [InlineData("http://192.168.1.20:5280/", true)]
+    [InlineData("http://192.168.1.20:5280", true)]
+    [InlineData("http://192.168.1.20:5280/index.html", false)]
+    [InlineData("http://192.168.1.20:5280/web/", false)]
+    [InlineData("http://192.168.1.20:5280/?key=abc", false)]
+    [InlineData("http://192.168.1.20:5280/#frag", false)]
+    [InlineData("http://192.168.1.20:5281/", false)]
+    public void WebRootAcceptsOnlyStrictRoot(string finalUrl, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            WorkstationNetwork.IsWebRoot(new Uri(finalUrl), "http://192.168.1.20:5280/"));
+    }
+
+    [Theory]
+    [InlineData("192.168.1.20:5280", null, "http://192.168.1.20:5280")]
+    [InlineData("192.168.1.20:5280", "abc 123", "http://192.168.1.20:5280/?key=abc%20123")]
+    public void WebAccessUrlBuildsKeyedUrl(string address, string? key, string expected)
+    {
+        Assert.Equal(expected, WorkstationNetwork.BuildWebAccessUrl(address, key));
+    }
+
+    [Fact]
+    public async Task ProbeAcceptsKeyedRootAndRejectsMissingKey()
+    {
+        const string accessKey = "secret-web-access-key";
+        string directory = Path.Combine(Path.GetTempPath(), $"epm-viewer-probe-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        int port = GetFreeTcpPort();
+        try
+        {
+            using var database = new VideoDatabase(Path.Combine(directory, "videos.db"));
+            using var server = new WebServer(
+                database,
+                port,
+                requireAccessKey: true,
+                accessKey: accessKey,
+                listenerHost: "127.0.0.1",
+                mobileBackupComputerId: Guid.NewGuid().ToString("D"),
+                mobileBackupStateDirectory: Path.Combine(directory, "uploads"),
+                mobileBackupRecordingRootResolver: () => Path.Combine(directory, "recordings"),
+                nodeId: Guid.NewGuid().ToString("D"),
+                nodeName: "查看端测试主机",
+                deploymentPreset: DeploymentPresets.MobileBackupHost);
+            server.Start();
+
+            WorkstationNetwork.WebAccessProbeResult authorized =
+                await WorkstationNetwork.ProbeWebAccessAsync(
+                    $"127.0.0.1:{port}",
+                    accessKey,
+                    TestContext.Current.CancellationToken);
+            WorkstationNetwork.WebAccessProbeResult denied =
+                await WorkstationNetwork.ProbeWebAccessAsync(
+                    $"127.0.0.1:{port}",
+                    null,
+                    TestContext.Current.CancellationToken);
+
+            Assert.Equal(WorkstationNetwork.WebAccessProbeResult.Authorized, authorized);
+            Assert.Equal(WorkstationNetwork.WebAccessProbeResult.Unauthorized, denied);
+        }
+        finally
+        {
+            SqliteTestPool.ClearPoolFor(directory);
+            try { Directory.Delete(directory, recursive: true); } catch { }
+        }
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/ExpressPackingMonitoring.Tests/ViewerWebAccessHostTests.cs
+++ b/ExpressPackingMonitoring.Tests/ViewerWebAccessHostTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using ExpressPackingMonitoring.Config;
+using ExpressPackingMonitoring.Data;
+using ExpressPackingMonitoring.Services;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace ExpressPackingMonitoring.Tests;
+
+[Collection("Web server tests")]
+public sealed class ViewerWebAccessHostTests
+{
+    [Fact]
+    public async Task NodeInfoExposesAccessProtectionState()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"epm-viewer-nodeinfo-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        int port = GetFreeTcpPort();
+        try
+        {
+            using var database = new VideoDatabase(Path.Combine(directory, "videos.db"));
+            using var server = new WebServer(
+                database,
+                port,
+                requireAccessKey: true,
+                accessKey: "secret-web-access-key",
+                listenerHost: "127.0.0.1",
+                mobileBackupComputerId: Guid.NewGuid().ToString("D"),
+                mobileBackupStateDirectory: Path.Combine(directory, "uploads"),
+                mobileBackupRecordingRootResolver: () => Path.Combine(directory, "recordings"),
+                nodeId: Guid.NewGuid().ToString("D"),
+                nodeName: "查看端测试主机",
+                deploymentPreset: DeploymentPresets.MobileBackupHost);
+            server.Start();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") };
+            string body = await client.GetStringAsync(
+                "/api/node-info",
+                TestContext.Current.CancellationToken);
+            using JsonDocument doc = JsonDocument.Parse(body);
+
+            Assert.True(doc.RootElement.GetProperty("accessProtected").GetBoolean());
+        }
+        finally
+        {
+            SqliteTestPool.ClearPoolFor(directory);
+            try { Directory.Delete(directory, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task ViewerEnrollmentReturnsWebAccessUrlAfterApproval()
+    {
+        const string accessKey = "secret-web-access-key";
+        string expectedUrl = $"http://192.168.1.20:5280/?key={accessKey}";
+        string directory = Path.Combine(Path.GetTempPath(), $"epm-viewer-enroll-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        int port = GetFreeTcpPort();
+        try
+        {
+            using var database = new VideoDatabase(Path.Combine(directory, "videos.db"));
+            using var server = new WebServer(
+                database,
+                port,
+                requireAccessKey: true,
+                accessKey: accessKey,
+                listenerHost: "127.0.0.1",
+                mobileConnectionUrlProvider: () => expectedUrl,
+                mobileBackupComputerId: Guid.NewGuid().ToString("D"),
+                mobileBackupStateDirectory: Path.Combine(directory, "uploads"),
+                mobileBackupRecordingRootResolver: () => Path.Combine(directory, "recordings"),
+                nodeId: Guid.NewGuid().ToString("D"),
+                nodeName: "查看端测试主机",
+                deploymentPreset: DeploymentPresets.MobileBackupHost,
+                backupDeviceEnrollmentApprover: _ => BackupDeviceEnrollmentApprovalDecision.Approved);
+            server.Start();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") };
+            using HttpResponseMessage response = await client.PostAsJsonAsync(
+                "/api/mobile-backup/enroll",
+                new
+                {
+                    deviceId = "viewer-device-0001",
+                    deviceName = "Mac 查看端",
+                    deviceKind = "viewer",
+                    platform = "macos",
+                    clientVersion = "0.0.49",
+                    clientBuildNumber = 0,
+                    backupProtocol = "mobile-backup-v2",
+                    enrollmentVersion = 2,
+                    authVersion = 3
+                },
+                TestContext.Current.CancellationToken);
+            response.EnsureSuccessStatusCode();
+            string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            using JsonDocument doc = JsonDocument.Parse(body);
+
+            Assert.Equal(expectedUrl, doc.RootElement.GetProperty("webAccessUrl").GetString());
+            Assert.Equal("Mac 查看端", doc.RootElement.GetProperty("deviceName").GetString());
+        }
+        finally
+        {
+            SqliteTestPool.ClearPoolFor(directory);
+            try { Directory.Delete(directory, recursive: true); } catch { }
+        }
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/ExpressPackingMonitoring/Config/AppConfig.cs
+++ b/ExpressPackingMonitoring/Config/AppConfig.cs
@@ -118,6 +118,8 @@ namespace ExpressPackingMonitoring.Config
         public string LastKnownHostNodeName { get; set; } = "";
         public string LastKnownHostAddress { get; set; } = "";
         public string LastKnownHostAccessKey { get; set; } = "";
+        // 查看端保存主机的网页访问密钥；与录制工位使用的设备令牌 LastKnownHostAccessKey 区分。
+        public string LastKnownHostWebAccessKey { get; set; } = "";
         public int LastKnownHostBackupAuthVersion { get; set; }
         public int BackupConnectionSchemaVersion { get; set; }
         public string RecordingCachePolicy { get; set; } = "KeepWithinSize";
@@ -423,6 +425,12 @@ namespace ExpressPackingMonitoring.Config
             if (!string.Equals(config.LastKnownHostAccessKey, normalizedHostAccessKey, StringComparison.Ordinal))
             {
                 config.LastKnownHostAccessKey = normalizedHostAccessKey;
+                changed = true;
+            }
+            string normalizedHostWebAccessKey = config.LastKnownHostWebAccessKey?.Trim() ?? "";
+            if (!string.Equals(config.LastKnownHostWebAccessKey, normalizedHostWebAccessKey, StringComparison.Ordinal))
+            {
+                config.LastKnownHostWebAccessKey = normalizedHostWebAccessKey;
                 changed = true;
             }
 

--- a/ExpressPackingMonitoring/Services/BackupCompatibilityPolicy.cs
+++ b/ExpressPackingMonitoring/Services/BackupCompatibilityPolicy.cs
@@ -10,6 +10,9 @@ internal static class BackupCompatibilityPolicy
     internal const string MinimumMobileVersion = "0.5.10";
     internal const int MinimumMobileBuildNumber = 11010;
     internal const string MinimumDesktopVersion = "0.0.32";
+    // Viewer enrollment 协议兼容下限，不代表任何客户端发布版本；
+    // 取 viewer 类型首次随主机发布的版本号（当前主线下一版本）。
+    internal const string MinimumViewerVersion = "0.0.49";
     internal const string MobileDownloadUrl =
         "https://gitee.com/PackingProof/PackingProof-Mobile/releases/latest";
     internal const string DesktopDownloadUrl =
@@ -35,11 +38,17 @@ internal static class BackupCompatibilityPolicy
 
     internal static BackupCompatibilityFailure? ValidateClient(BackupDeviceEnrollmentRequest request)
     {
-        bool mobile = !string.Equals(request.DeviceKind, "pc", StringComparison.OrdinalIgnoreCase);
-        string minimumVersion = mobile ? MinimumMobileVersion : MinimumDesktopVersion;
+        bool workstation = string.Equals(request.DeviceKind, "pc", StringComparison.OrdinalIgnoreCase);
+        bool viewer = string.Equals(request.DeviceKind, "viewer", StringComparison.OrdinalIgnoreCase);
+        bool mobile = !workstation && !viewer;
+        string minimumVersion = viewer
+            ? MinimumViewerVersion
+            : workstation
+                ? MinimumDesktopVersion
+                : MinimumMobileVersion;
         int minimumBuildNumber = mobile ? MinimumMobileBuildNumber : 0;
         string downloadUrl = mobile ? MobileDownloadUrl : DesktopDownloadUrl;
-        string updateTarget = mobile ? "mobile" : "recording-workstation";
+        string updateTarget = viewer ? "viewer" : mobile ? "mobile" : "recording-workstation";
 
         bool protocolCompatible = string.Equals(
                 request.BackupProtocol,
@@ -52,9 +61,11 @@ internal static class BackupCompatibilityPolicy
         if (protocolCompatible && versionCompatible && buildCompatible)
             return null;
 
-        string message = mobile
-            ? "手机 App 版本过低，请更新后重新连接"
-            : "录制工位版本过低，请更新电脑端后重新连接";
+        string message = viewer
+            ? "查看端版本过低，请更新后重新连接"
+            : mobile
+                ? "手机 App 版本过低，请更新后重新连接"
+                : "录制工位版本过低，请更新电脑端后重新连接";
         return new BackupCompatibilityFailure(
             updateTarget,
             minimumVersion,

--- a/ExpressPackingMonitoring/Services/PackingProofNodeInfo.cs
+++ b/ExpressPackingMonitoring/Services/PackingProofNodeInfo.cs
@@ -29,6 +29,13 @@ public sealed class PackingProofNodeInfo
     [JsonPropertyName("httpPort")]
     public int HttpPort { get; set; }
 
+    /// <summary>
+    /// 主机是否开启网页访问保护。旧版本主机不返回该字段，因此使用可空类型
+    /// 区分“明确未保护”（false）与“无法确认”（null）。
+    /// </summary>
+    [JsonPropertyName("accessProtected")]
+    public bool? AccessProtected { get; set; }
+
     [JsonPropertyName("backupCompatibility")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public BackupCompatibilityInfo? BackupCompatibility { get; set; }

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -1142,7 +1142,9 @@ namespace ExpressPackingMonitoring.Services
         private static string NormalizeDeviceKind(string deviceKind) =>
             string.Equals(deviceKind, "pc", StringComparison.OrdinalIgnoreCase)
                 ? "pc"
-                : "mobile";
+                : string.Equals(deviceKind, "viewer", StringComparison.OrdinalIgnoreCase)
+                    ? "viewer"
+                    : "mobile";
 
         private static bool IsMobileBackupUploadPath(string path, string suffix, out string uploadId)
         {
@@ -1319,7 +1321,7 @@ namespace ExpressPackingMonitoring.Services
                 return;
             }
             BackupDeviceEnrollment enrollment = operation.Enrollment;
-            MobileOrderReceiverInfo? registeredDevice = null;
+            MobileOrderReceiverInfo registeredDevice = null;
             // 查看端只消费网页回放，不参与订单播报接收，不注册为订单接收设备。
             if (!string.Equals(deviceKind, "viewer", StringComparison.OrdinalIgnoreCase))
             {
@@ -1329,7 +1331,7 @@ namespace ExpressPackingMonitoring.Services
                     request.DeviceName);
             }
             string assignedDeviceName = registeredDevice?.NodeName ?? request.DeviceName;
-            string? webAccessUrl = ResolveWebAccessUrl();
+            string webAccessUrl = ResolveWebAccessUrl();
             SendJson(ctx, 200, new
             {
                 protocol = MobileBackupService.ProtocolVersion,
@@ -1346,21 +1348,17 @@ namespace ExpressPackingMonitoring.Services
             });
         }
 
-        private static string NormalizeDeviceKind(string? kind) =>
-            string.Equals(kind, "pc", StringComparison.OrdinalIgnoreCase) ? "pc"
-            : string.Equals(kind, "viewer", StringComparison.OrdinalIgnoreCase) ? "viewer"
-            : "mobile";
-
         /// <summary>
         /// 与“连接手机/电脑”使用同一链接：受保护时带 ?key=，未保护时为裸地址；
         /// 提供者不可用时返回 null，由客户端按受保护状态处理，绝不降级为无认证打开。
         /// </summary>
-        private string? ResolveWebAccessUrl()
+        private string ResolveWebAccessUrl()
         {
             try
             {
                 string url = _mobileConnectionUrlProvider()?.Trim() ?? "";
-                return Uri.TryCreate(url, UriKind.Absolute, out Uri? parsed)
+                Uri parsed = null;
+                return Uri.TryCreate(url, UriKind.Absolute, out parsed)
                     && (string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                     ? url

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -52,6 +52,8 @@ namespace ExpressPackingMonitoring.Services
         public string DeviceId { get; set; } = "";
         public string DeviceName { get; set; } = "";
         public string DeviceKind { get; set; } = "mobile";
+        // 仅供批准弹窗展示（macos/windows），不参与任何校验或服务端分支。
+        public string Platform { get; set; } = "";
         public string RemoteAddress { get; set; } = "";
         public string ClientVersion { get; set; } = "";
         public int ClientBuildNumber { get; set; }
@@ -932,6 +934,7 @@ namespace ExpressPackingMonitoring.Services
                 Preset = _deploymentPreset,
                 Capabilities = PackingProofCapabilities.ForPreset(_deploymentPreset).ToList(),
                 HttpPort = Port,
+                AccessProtected = _requireAccessKey,
                 BackupCompatibility = PackingProofCapabilities.ForPreset(_deploymentPreset).Contains(
                     PackingProofCapabilities.MobileBackup,
                     StringComparer.OrdinalIgnoreCase)
@@ -1199,12 +1202,11 @@ namespace ExpressPackingMonitoring.Services
                 return;
             }
             string deviceId = request.DeviceId?.Trim() ?? "";
-            string deviceKind = string.Equals(request.DeviceKind, "pc", StringComparison.OrdinalIgnoreCase)
-                ? "pc"
-                : "mobile";
+            string deviceKind = NormalizeDeviceKind(request.DeviceKind);
             request.DeviceId = deviceId;
             request.DeviceKind = deviceKind;
             request.DeviceName = (request.DeviceName ?? "").Trim();
+            request.Platform = (request.Platform ?? "").Trim();
             request.RemoteAddress = remoteAddress;
             if (deviceId.Length is < 8 or > 128)
             {
@@ -1317,11 +1319,17 @@ namespace ExpressPackingMonitoring.Services
                 return;
             }
             BackupDeviceEnrollment enrollment = operation.Enrollment;
-            MobileOrderReceiverInfo registeredDevice = _mobileOrderReceivers.Register(
-                ctx.Request.RemoteEndPoint?.Address,
-                enrollment.DeviceId,
-                request.DeviceName);
+            MobileOrderReceiverInfo? registeredDevice = null;
+            // 查看端只消费网页回放，不参与订单播报接收，不注册为订单接收设备。
+            if (!string.Equals(deviceKind, "viewer", StringComparison.OrdinalIgnoreCase))
+            {
+                registeredDevice = _mobileOrderReceivers.Register(
+                    ctx.Request.RemoteEndPoint?.Address,
+                    enrollment.DeviceId,
+                    request.DeviceName);
+            }
             string assignedDeviceName = registeredDevice?.NodeName ?? request.DeviceName;
+            string? webAccessUrl = ResolveWebAccessUrl();
             SendJson(ctx, 200, new
             {
                 protocol = MobileBackupService.ProtocolVersion,
@@ -1333,8 +1341,35 @@ namespace ExpressPackingMonitoring.Services
                 deviceToken = enrollment.DeviceCredential,
                 deviceName = assignedDeviceName,
                 issuedAt = enrollment.IssuedAt,
-                hostVersion = BackupCompatibilityPolicy.CreateHostInfo().HostVersion
+                hostVersion = BackupCompatibilityPolicy.CreateHostInfo().HostVersion,
+                webAccessUrl = webAccessUrl
             });
+        }
+
+        private static string NormalizeDeviceKind(string? kind) =>
+            string.Equals(kind, "pc", StringComparison.OrdinalIgnoreCase) ? "pc"
+            : string.Equals(kind, "viewer", StringComparison.OrdinalIgnoreCase) ? "viewer"
+            : "mobile";
+
+        /// <summary>
+        /// 与“连接手机/电脑”使用同一链接：受保护时带 ?key=，未保护时为裸地址；
+        /// 提供者不可用时返回 null，由客户端按受保护状态处理，绝不降级为无认证打开。
+        /// </summary>
+        private string? ResolveWebAccessUrl()
+        {
+            try
+            {
+                string url = _mobileConnectionUrlProvider()?.Trim() ?? "";
+                return Uri.TryCreate(url, UriKind.Absolute, out Uri? parsed)
+                    && (string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                    ? url
+                    : null;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private void ClearRecentBackupEnrollment()

--- a/ExpressPackingMonitoring/UI/BackupDeviceEnrollmentApprovalWindow.xaml.cs
+++ b/ExpressPackingMonitoring/UI/BackupDeviceEnrollmentApprovalWindow.xaml.cs
@@ -13,14 +13,23 @@ public partial class BackupDeviceEnrollmentApprovalWindow : Window
     internal BackupDeviceEnrollmentApprovalWindow(BackupDeviceEnrollmentRequest request)
     {
         InitializeComponent();
-        string kind = string.Equals(request.DeviceKind, "pc", StringComparison.OrdinalIgnoreCase)
+        bool isWorkstation = string.Equals(request.DeviceKind, "pc", StringComparison.OrdinalIgnoreCase);
+        bool isViewer = string.Equals(request.DeviceKind, "viewer", StringComparison.OrdinalIgnoreCase);
+        string kind = isWorkstation
             ? "录制电脑"
-            : "手机";
+            : isViewer
+                ? "电脑查看端"
+                : "手机";
         string name = string.IsNullOrWhiteSpace(request.DeviceName) ? kind : request.DeviceName;
-        string permission = string.Equals(request.DeviceKind, "pc", StringComparison.OrdinalIgnoreCase)
+        string permission = isWorkstation
             ? "允许后，这台录制电脑可以上传、查看和确认自己录制的录像"
-            : "允许后，这台手机可以上传自己的录像，并查看、播放、下载和剪辑保存主机中的录像；不能删除主机录像或修改设置";
-        MessageText.Text = $"{name}（{request.RemoteAddress}）申请连接这台保存主机。{permission}";
+            : isViewer
+                ? "允许后，这台查看端可以查看、播放、下载和剪辑保存主机中的录像；不能删除主机录像或修改设置"
+                : "允许后，这台手机可以上传自己的录像，并查看、播放、下载和剪辑保存主机中的录像；不能删除主机录像或修改设置";
+        string location = string.IsNullOrWhiteSpace(request.Platform)
+            ? request.RemoteAddress
+            : $"{request.Platform} · {request.RemoteAddress}";
+        MessageText.Text = $"{name}（{location}）申请连接这台保存主机。{permission}";
 
         _expiryTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(60) };
         _expiryTimer.Tick += ExpiryTimer_Tick;

--- a/ExpressPackingMonitoring/Workstations/ViewerClientWindow.xaml.cs
+++ b/ExpressPackingMonitoring/Workstations/ViewerClientWindow.xaml.cs
@@ -348,6 +348,7 @@ public partial class ViewerClientWindow : Window
         ApplyConnectionViewState(
             ConnectionViewState.Connecting,
             $"正在连接“{node.NodeName}”");
+        string previousHostNodeId = _config.LastKnownHostNodeId;
         if (!WorkstationConfigStore.TryUpdate(
                 config =>
                 {
@@ -368,6 +369,21 @@ public partial class ViewerClientWindow : Window
                         config.BackupConnectionSchemaVersion =
                             AppConfig.CurrentBackupConnectionSchemaVersion;
                     }
+                    else
+                    {
+                        // 查看模式：粘贴链接携带的 key 持久化；更换主机时清除旧 key。
+                        if (!string.IsNullOrWhiteSpace(accessKey))
+                        {
+                            config.LastKnownHostWebAccessKey = accessKey.Trim();
+                        }
+                        else if (!string.Equals(
+                                     previousHostNodeId,
+                                     node.NodeId,
+                                     StringComparison.OrdinalIgnoreCase))
+                        {
+                            config.LastKnownHostWebAccessKey = "";
+                        }
+                    }
                     AppConfig.MarkDeploymentSetupCompleted(config);
                 },
                 out AppConfig saved,
@@ -382,6 +398,7 @@ public partial class ViewerClientWindow : Window
         _config.LastKnownHostNodeName = saved.LastKnownHostNodeName;
         _config.LastKnownHostAddress = saved.LastKnownHostAddress;
         _config.LastKnownHostAccessKey = saved.LastKnownHostAccessKey;
+        _config.LastKnownHostWebAccessKey = saved.LastKnownHostWebAccessKey;
         _config.LastKnownHostBackupAuthVersion = saved.LastKnownHostBackupAuthVersion;
         _config.BackupConnectionSchemaVersion = saved.BackupConnectionSchemaVersion;
         _config.FirstUseWizardCompleted = saved.FirstUseWizardCompleted;
@@ -410,11 +427,182 @@ public partial class ViewerClientWindow : Window
         }
     }
 
-    private void OpenWeb_Click(object sender, RoutedEventArgs e)
+    private async void OpenWeb_Click(object sender, RoutedEventArgs e)
     {
         string address = _boundHost?.Address ?? _config.LastKnownHostAddress;
-        if (!WorkstationNetwork.TryOpenUrl(address, out string error))
-            AppDialog.Error(this, error, "打开录像网页失败");
+        if (string.IsNullOrWhiteSpace(address))
+        {
+            AppDialog.Warning(this, "请先搜索并连接一台主机", "打开录像网页");
+            return;
+        }
+
+        OpenWebButton.IsEnabled = false;
+        try
+        {
+            bool? protectedState = _boundHost?.AccessProtected;
+            if (protectedState == false)
+            {
+                WorkstationNetwork.OpenUrl(address);
+                return;
+            }
+
+            if (protectedState == null)
+            {
+                await OpenLegacyHostWebAsync(address);
+                return;
+            }
+
+            await OpenProtectedHostWebAsync(address);
+        }
+        finally
+        {
+            OpenWebButton.IsEnabled = _boundHost != null;
+        }
+    }
+
+    /// <summary>
+    /// 旧主机不返回 accessProtected：先裸地址预检，再尝试已存 key，
+    /// 都失败时给出升级或粘贴链接提示，绝不无认证拉起浏览器。
+    /// </summary>
+    private async Task OpenLegacyHostWebAsync(string address)
+    {
+        // 优先用协议字段判断：主机已返回受保护状态时走标准流程。
+        PackingProofNodeInfo? node = await WorkstationNetwork.GetNodeInfoAsync(address);
+        if (node?.AccessProtected == true)
+        {
+            await OpenProtectedHostWebAsync(address);
+            return;
+        }
+
+        WorkstationNetwork.WebAccessProbeResult probe =
+            await WorkstationNetwork.ProbeWebAccessAsync(address);
+        if (probe == WorkstationNetwork.WebAccessProbeResult.Authorized)
+        {
+            WorkstationNetwork.OpenUrl(address);
+            return;
+        }
+        if (probe == WorkstationNetwork.WebAccessProbeResult.Failed)
+        {
+            AppDialog.Error(this, "无法连接保存主机网页，请检查网络后重试", "打开录像网页");
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_config.LastKnownHostWebAccessKey))
+        {
+            probe = await WorkstationNetwork.ProbeWebAccessAsync(
+                address,
+                _config.LastKnownHostWebAccessKey);
+            if (probe == WorkstationNetwork.WebAccessProbeResult.Authorized)
+            {
+                WorkstationNetwork.OpenUrl(WorkstationNetwork.BuildWebAccessUrl(
+                    address,
+                    _config.LastKnownHostWebAccessKey));
+                return;
+            }
+        }
+
+        AppDialog.Warning(
+            this,
+            "保存主机版本过旧或已开启访问保护，请更新保存主机，或使用“手动连接”粘贴完整链接",
+            "打开录像网页");
+    }
+
+    /// <summary>
+    /// 受保护主机：有 key 先预检；401 则清除旧 key、自动申请一次并再次预检；
+    /// 只有预检通过才打开浏览器，申请成功不直接信任返回链接。
+    /// </summary>
+    private async Task OpenProtectedHostWebAsync(string address)
+    {
+        string? key = _config.LastKnownHostWebAccessKey;
+        if (!string.IsNullOrWhiteSpace(key))
+        {
+            WorkstationNetwork.WebAccessProbeResult probe =
+                await WorkstationNetwork.ProbeWebAccessAsync(address, key);
+            if (probe == WorkstationNetwork.WebAccessProbeResult.Authorized)
+            {
+                WorkstationNetwork.OpenUrl(WorkstationNetwork.BuildWebAccessUrl(address, key));
+                return;
+            }
+            if (probe == WorkstationNetwork.WebAccessProbeResult.Failed)
+            {
+                AppDialog.Error(this, "无法连接保存主机网页，请检查网络后重试", "打开录像网页");
+                return;
+            }
+            ClearSavedWebAccessKey();
+        }
+
+        SearchStatusText.Text = "正在请求保存主机允许连接";
+        string url;
+        try
+        {
+            BackupDeviceEnrollmentResult enrollment =
+                await WorkstationNetwork.EnrollBackupDeviceAsync(
+                    address,
+                    _config.NodeId,
+                    string.IsNullOrWhiteSpace(_config.NodeName)
+                        ? Environment.MachineName
+                        : _config.NodeName,
+                    "viewer",
+                    clientVersion: BackupCompatibilityPolicy.MinimumViewerVersion,
+                    platform: "windows");
+            url = enrollment.WebAccessUrl ?? "";
+        }
+        catch (Exception ex)
+        {
+            SearchStatusText.Text = "未取得网页访问权限";
+            AppDialog.Error(this, ex.Message, "打开录像网页");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            SearchStatusText.Text = "未取得网页访问权限";
+            AppDialog.Error(this, "保存主机未返回网页访问链接，请更新保存主机后重试", "打开录像网页");
+            return;
+        }
+
+        WorkstationNetwork.ParseHostConnectionInput(url, out _, out string issuedKey);
+        if (issuedKey.Length == 0)
+        {
+            SearchStatusText.Text = "未取得网页访问权限";
+            AppDialog.Error(this, "保存主机返回的网页访问链接无效，请更新保存主机后重试", "打开录像网页");
+            return;
+        }
+
+        WorkstationNetwork.WebAccessProbeResult finalProbe =
+            await WorkstationNetwork.ProbeWebAccessAsync(address, issuedKey);
+        if (finalProbe != WorkstationNetwork.WebAccessProbeResult.Authorized)
+        {
+            SearchStatusText.Text = "未取得网页访问权限";
+            AppDialog.Error(this, "网页访问验证失败，请在保存主机上确认后重试", "打开录像网页");
+            return;
+        }
+
+        SaveWebAccessKey(issuedKey);
+        SearchStatusText.Text = "已允许访问";
+        WorkstationNetwork.OpenUrl(WorkstationNetwork.BuildWebAccessUrl(address, issuedKey));
+    }
+
+    private void SaveWebAccessKey(string key)
+    {
+        if (WorkstationConfigStore.TryUpdate(
+                config => config.LastKnownHostWebAccessKey = key.Trim(),
+                out AppConfig saved,
+                out _))
+        {
+            _config.LastKnownHostWebAccessKey = saved.LastKnownHostWebAccessKey;
+        }
+    }
+
+    private void ClearSavedWebAccessKey()
+    {
+        if (WorkstationConfigStore.TryUpdate(
+                config => config.LastKnownHostWebAccessKey = "",
+                out AppConfig saved,
+                out _))
+        {
+            _config.LastKnownHostWebAccessKey = saved.LastKnownHostWebAccessKey;
+        }
     }
 
     private async void SearchHosts_Click(object sender, RoutedEventArgs e) => await SearchHostsAsync();

--- a/ExpressPackingMonitoring/Workstations/WorkstationLauncher.cs
+++ b/ExpressPackingMonitoring/Workstations/WorkstationLauncher.cs
@@ -255,7 +255,6 @@ public static class WorkstationNetwork
     private static readonly HttpClient Client = CreateLanHttpClient(TimeSpan.FromSeconds(3));
     private static readonly HttpClient TestOrderClient = CreateLanHttpClient(TimeSpan.FromSeconds(3));
     private static readonly HttpClient LoopbackClient = CreateLanHttpClient(TimeSpan.FromSeconds(3));
-    private static readonly HttpClient WebAccessProbeClient = CreateLanHttpClient(TimeSpan.FromSeconds(8));
     private static readonly JsonSerializerOptions NetworkJsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -942,8 +941,14 @@ public static class WorkstationNetwork
         string url = BuildWebAccessUrl(normalized, accessKey);
         try
         {
+            // 每次预检使用独立客户端：服务端在带 key 请求上种 cookie，
+            // 共享客户端会把 cookie 泄漏到下一次裸地址探测。
+            using var client = new HttpClient(new SocketsHttpHandler { UseProxy = false })
+            {
+                Timeout = TimeSpan.FromSeconds(8)
+            };
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            using var response = await WebAccessProbeClient.SendAsync(
+            using var response = await client.SendAsync(
                 request,
                 HttpCompletionOption.ResponseContentRead,
                 token);

--- a/ExpressPackingMonitoring/Workstations/WorkstationLauncher.cs
+++ b/ExpressPackingMonitoring/Workstations/WorkstationLauncher.cs
@@ -255,6 +255,7 @@ public static class WorkstationNetwork
     private static readonly HttpClient Client = CreateLanHttpClient(TimeSpan.FromSeconds(3));
     private static readonly HttpClient TestOrderClient = CreateLanHttpClient(TimeSpan.FromSeconds(3));
     private static readonly HttpClient LoopbackClient = CreateLanHttpClient(TimeSpan.FromSeconds(3));
+    private static readonly HttpClient WebAccessProbeClient = CreateLanHttpClient(TimeSpan.FromSeconds(8));
     private static readonly JsonSerializerOptions NetworkJsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -606,13 +607,18 @@ public static class WorkstationNetwork
         string deviceName,
         string deviceKind,
         CancellationToken token = default,
-        Func<TimeSpan, CancellationToken, Task>? retryDelay = null)
+        Func<TimeSpan, CancellationToken, Task>? retryDelay = null,
+        string? clientVersion = null,
+        string? platform = null)
     {
         address = NormalizeAddress(address);
         if (address.Length == 0 || string.IsNullOrWhiteSpace(deviceId))
             throw new InvalidOperationException("保存主机地址或本机身份无效");
         using var client = CreateLanHttpClient(TimeSpan.FromSeconds(90));
         retryDelay ??= Task.Delay;
+        string resolvedClientVersion = string.IsNullOrWhiteSpace(clientVersion)
+            ? BackupCompatibilityPolicy.MinimumDesktopVersion
+            : clientVersion.Trim();
         for (int attempt = 0; ; attempt++)
         {
             using var request = new HttpRequestMessage(
@@ -625,8 +631,11 @@ public static class WorkstationNetwork
                     deviceName = deviceName?.Trim() ?? "",
                     deviceKind = string.Equals(deviceKind, "pc", StringComparison.OrdinalIgnoreCase)
                         ? "pc"
-                        : "mobile",
-                    clientVersion = BackupCompatibilityPolicy.MinimumDesktopVersion,
+                        : string.Equals(deviceKind, "viewer", StringComparison.OrdinalIgnoreCase)
+                            ? "viewer"
+                            : "mobile",
+                    platform = platform ?? "",
+                    clientVersion = resolvedClientVersion,
                     clientBuildNumber = 0,
                     backupProtocol = BackupCompatibilityPolicy.BackupProtocol,
                     enrollmentVersion = BackupCompatibilityPolicy.EnrollmentVersion,
@@ -896,6 +905,75 @@ public static class WorkstationNetwork
     public static void OpenUrl(string url)
     {
         TryOpenUrl(url, out _);
+    }
+
+    internal enum WebAccessProbeResult
+    {
+        Authorized,
+        Unauthorized,
+        Failed
+    }
+
+    /// <summary>
+    /// 构造网页访问地址；有 key 时带 ?key=，由服务端校验并种 cookie。
+    /// </summary>
+    internal static string BuildWebAccessUrl(string address, string? accessKey)
+    {
+        string url = ToUrl(address).TrimEnd('/');
+        return string.IsNullOrWhiteSpace(accessKey)
+            ? url
+            : $"{url}/?key={Uri.EscapeDataString(accessKey.Trim())}";
+    }
+
+    /// <summary>
+    /// 网页访问预检：自动跟随重定向。只有最终状态码 200 且最终 URL 仍严格为
+    /// 主机根路径（scheme/host/端口相同、path 为 "/"、无 query、无 fragment）
+    /// 才算主机明确接受；401 视为 key 无效；其余情况一律视为失败。
+    /// </summary>
+    internal static async Task<WebAccessProbeResult> ProbeWebAccessAsync(
+        string address,
+        string? accessKey = null,
+        CancellationToken token = default)
+    {
+        string normalized = NormalizeAddress(address);
+        if (normalized.Length == 0)
+            return WebAccessProbeResult.Failed;
+
+        string url = BuildWebAccessUrl(normalized, accessKey);
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var response = await WebAccessProbeClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseContentRead,
+                token);
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                return WebAccessProbeResult.Unauthorized;
+            if (!response.IsSuccessStatusCode
+                || !IsWebRoot(response.RequestMessage?.RequestUri, url))
+                return WebAccessProbeResult.Failed;
+            return WebAccessProbeResult.Authorized;
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+            or TaskCanceledException
+            or InvalidOperationException)
+        {
+            return WebAccessProbeResult.Failed;
+        }
+    }
+
+    internal static bool IsWebRoot(Uri? finalUri, string expectedUrl)
+    {
+        if (finalUri == null
+            || !Uri.TryCreate(expectedUrl, UriKind.Absolute, out Uri? expected))
+            return false;
+
+        return string.Equals(finalUri.Scheme, expected.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(finalUri.Host, expected.Host, StringComparison.OrdinalIgnoreCase)
+            && finalUri.Port == expected.Port
+            && string.Equals(finalUri.AbsolutePath, "/", StringComparison.Ordinal)
+            && string.IsNullOrEmpty(finalUri.Query)
+            && string.IsNullOrEmpty(finalUri.Fragment);
     }
 
     public static bool TryRestartApplication(string reason = "unspecified", Window? owner = null)
@@ -1251,6 +1329,7 @@ internal sealed class BackupDeviceEnrollmentResult
     public string ComputerName { get; set; } = "";
     public string DeviceId { get; set; } = "";
     public string DeviceToken { get; set; } = "";
+    public string? WebAccessUrl { get; set; }
     public string HostVersion { get; set; } = "";
 }
 


### PR DESCRIPTION
查看端（Windows/Mac）通过注册申请获批准后取得带 key 的网页访问链接；打开网页前统一预检，受保护主机绝不无认证打开。

- node-info 增加 accessProtected；注册新增 viewer 类型，批准回包携带 webAccessUrl
- key 失效最多自动申请一次；旧主机回退粘贴完整链接

验证：依赖 Windows CI（dotnet build / dotnet test）