### PR TITLE
feat: Apple 客户端直传 HEVC 按 hvc1 流拷贝并修复 -12939

### DIFF
--- a/ExpressPackingMonitoring.Tests/DirectAacRecordingTests.cs
+++ b/ExpressPackingMonitoring.Tests/DirectAacRecordingTests.cs
@@ -57,6 +57,38 @@ public sealed class DirectAacRecordingTests
     }
 
     [Theory]
+    [InlineData("h265")]
+    [InlineData("hevc")]
+    public void HevcMkvConversion_WritesHvc1Tag(string videoCodec)
+    {
+        string args = MainViewModel.BuildMkvToMp4Args(
+            "recording.mkv",
+            null,
+            "recording.mp4",
+            250,
+            videoCodec);
+
+        Assert.Contains("-tag:v hvc1", args);
+    }
+
+    [Theory]
+    [InlineData("h264")]
+    [InlineData("av1")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void NonHevcMkvConversion_KeepsDefaultVideoTag(string? videoCodec)
+    {
+        string args = MainViewModel.BuildMkvToMp4Args(
+            "recording.mkv",
+            null,
+            "recording.mp4",
+            250,
+            videoCodec);
+
+        Assert.DoesNotContain("-tag:v hvc1", args);
+    }
+
+    [Theory]
     [InlineData(250, 24000)]
     [InlineData(-250, -24000)]
     [InlineData(9000, 480000)]

--- a/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
+++ b/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
@@ -45,7 +45,6 @@ public sealed class WebRequestLimitTests
 
     [Theory]
     [InlineData("h265", true)]
-    [InlineData("H265", true)]
     [InlineData("hevc", true)]
     [InlineData("h264", false)]
     [InlineData("av1", false)]

--- a/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
+++ b/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
@@ -36,6 +36,8 @@ public sealed class WebRequestLimitTests
     [InlineData("AppleCoreMedia/1.0.0.21A329 (iPhone; U; CPU OS 18_3 like Mac OS X; zh_cn)", true)]
     [InlineData("AppleCoreMedia/1.0 (Macintosh; U; Intel Mac OS X)", true)]
     [InlineData("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15", true)]
+    [InlineData("Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Mobile/15E148 Safari/604.1", true)]
+    [InlineData("Mozilla/5.0 (iPad; CPU OS 18_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Mobile/15E148 Safari/604.1", true)]
     [InlineData("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36", false)]
     [InlineData("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36", false)]
     [InlineData("", false)]

--- a/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
+++ b/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
@@ -35,12 +35,14 @@ public sealed class WebRequestLimitTests
     [Theory]
     [InlineData("AppleCoreMedia/1.0.0.21A329 (iPhone; U; CPU OS 18_3 like Mac OS X; zh_cn)", true)]
     [InlineData("AppleCoreMedia/1.0 (Macintosh; U; Intel Mac OS X)", true)]
+    [InlineData("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15", true)]
+    [InlineData("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36", false)]
     [InlineData("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36", false)]
     [InlineData("", false)]
     [InlineData(null, false)]
-    public void IsAppleCoreMediaUserAgent_OnlyRecognizesAppleMediaStack(string? userAgent, bool expected)
+    public void IsApplePlaybackClientUserAgent_OnlyRecognizesAppleClients(string? userAgent, bool expected)
     {
-        Assert.Equal(expected, WebServer.IsAppleCoreMediaUserAgent(userAgent));
+        Assert.Equal(expected, WebServer.IsApplePlaybackClientUserAgent(userAgent));
     }
 
     [Theory]

--- a/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
+++ b/ExpressPackingMonitoring.Tests/WebRequestLimitTests.cs
@@ -33,6 +33,29 @@ public sealed class WebRequestLimitTests
     }
 
     [Theory]
+    [InlineData("AppleCoreMedia/1.0.0.21A329 (iPhone; U; CPU OS 18_3 like Mac OS X; zh_cn)", true)]
+    [InlineData("AppleCoreMedia/1.0 (Macintosh; U; Intel Mac OS X)", true)]
+    [InlineData("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsAppleCoreMediaUserAgent_OnlyRecognizesAppleMediaStack(string? userAgent, bool expected)
+    {
+        Assert.Equal(expected, WebServer.IsAppleCoreMediaUserAgent(userAgent));
+    }
+
+    [Theory]
+    [InlineData("h265", true)]
+    [InlineData("H265", true)]
+    [InlineData("hevc", true)]
+    [InlineData("h264", false)]
+    [InlineData("av1", false)]
+    [InlineData("", false)]
+    public void IsHevcVideoCodec_OnlyAcceptsHevcAliases(string codec, bool expected)
+    {
+        Assert.Equal(expected, WebServer.IsHevcVideoCodec(codec));
+    }
+
+    [Theory]
     [InlineData("bytes=0-99", 1000, 0, 99)]
     [InlineData("bytes=900-", 1000, 900, 999)]
     [InlineData("bytes=-100", 1000, 900, 999)]

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -3447,8 +3447,8 @@ namespace ExpressPackingMonitoring.Services
 
         /// <summary>
         /// 识别 Apple 媒体播放客户端：iOS/AVFoundation 的媒体请求带 AppleCoreMedia UA；
-        /// macOS Safari 的 video 媒体请求使用普通 Safari UA，不含 AppleCoreMedia，
-        /// 因此额外识别“Macintosh + Safari/ 且非 Chrome/Edge/Opera”，
+        /// Apple 各端 Safari 的 video 媒体请求使用普通 Safari UA，不含 AppleCoreMedia，
+        /// 因此额外识别“Safari/ 且非 Chrome/Edge/Opera，且设备为 Macintosh/iPhone/iPad/iPod”，
         /// 让 Safari 同样进入 hev1→hvc1 拷贝与 Range 转码分支。
         /// </summary>
         internal static bool IsApplePlaybackClientUserAgent(string userAgent)
@@ -3459,11 +3459,16 @@ namespace ExpressPackingMonitoring.Services
             if (userAgent.Contains("AppleCoreMedia", StringComparison.OrdinalIgnoreCase))
                 return true;
 
-            return userAgent.Contains("Safari/", StringComparison.OrdinalIgnoreCase)
-                && userAgent.Contains("Macintosh", StringComparison.OrdinalIgnoreCase)
-                && !userAgent.Contains("Chrome/", StringComparison.OrdinalIgnoreCase)
-                && !userAgent.Contains("Edg/", StringComparison.OrdinalIgnoreCase)
-                && !userAgent.Contains("OPR/", StringComparison.OrdinalIgnoreCase);
+            if (!userAgent.Contains("Safari/", StringComparison.OrdinalIgnoreCase)
+                || userAgent.Contains("Chrome/", StringComparison.OrdinalIgnoreCase)
+                || userAgent.Contains("Edg/", StringComparison.OrdinalIgnoreCase)
+                || userAgent.Contains("OPR/", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return userAgent.Contains("Macintosh", StringComparison.OrdinalIgnoreCase)
+                || userAgent.Contains("iPhone", StringComparison.OrdinalIgnoreCase)
+                || userAgent.Contains("iPad", StringComparison.OrdinalIgnoreCase)
+                || userAgent.Contains("iPod", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -3145,7 +3145,10 @@ namespace ExpressPackingMonitoring.Services
             bool shouldTranscode = compatMode && codec != "" && codec != "h264";
             bool recording = _isRecordingProvider();
             bool hasTranscodeCache = shouldTranscode && HasTranscodeCache(filePath);
-            Log($"HandlePlay: codec='{codec}', compat={(compatMode ? "1" : "0")}, 判定={(shouldTranscode ? "转码" : "直传")}");
+            bool appleCoreMedia = IsAppleCoreMediaRequest(ctx);
+            string userAgent = ctx.Request.UserAgent ?? "";
+            if (userAgent.Length > 120) userAgent = userAgent.Substring(0, 120);
+            Log($"HandlePlay: codec='{codec}', compat={(compatMode ? "1" : "0")}, 判定={(shouldTranscode ? "转码" : "直传")}, appleCoreMedia={appleCoreMedia}, ua={userAgent}");
 
             if (shouldTranscode && recording && !allowTranscodeWhileRecording && !hasTranscodeCache)
             {
@@ -3173,11 +3176,19 @@ namespace ExpressPackingMonitoring.Services
             {
                 ServeTranscodedStream(ctx, filePath);
             }
+            else if (appleCoreMedia && IsHevcVideoCodec(codec)
+                && filePath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase))
+            {
+                ServeAppleCompatibleMp4(ctx, filePath);
+            }
             else
             {
                 ServeFileWithRange(ctx, filePath, inline: true);
             }
         }
+
+        private static bool IsHevcVideoCodec(string codec)
+            => codec == "h265" || codec == "hevc";
 
         private string EnsureMp4ContainerForPlayback(HttpListenerContext ctx, VideoRecord record)
         {
@@ -3272,6 +3283,68 @@ namespace ExpressPackingMonitoring.Services
             return Path.Combine(_transCacheDir, $"{cacheKey}.mp4");
         }
 
+        private static string GetAppleCompatibleCachePath(string filePath)
+        {
+            string cacheKey = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+                Encoding.UTF8.GetBytes(filePath))).Substring(0, 16);
+            return Path.Combine(_transCacheDir, $"{cacheKey}.apple.mp4");
+        }
+
+        /// <summary>
+        /// Apple 客户端直传 HEVC 原片前，把 MP4 的 hev1 采样标签流拷贝为 hvc1 并缓存。
+        /// 苹果解码器不识别 NVENC 默认写出的 hev1 标签（白屏或 Cannot Decode），
+        /// hvc1 则可原生硬解。纯流拷贝不重新编码，只做一次并复用缓存；
+        /// ffmpeg 不可用或拷贝失败时回退直传原片，不影响其他客户端。
+        /// </summary>
+        private void ServeAppleCompatibleMp4(HttpListenerContext ctx, string filePath)
+        {
+            string cachePath = GetAppleCompatibleCachePath(filePath);
+            if (File.Exists(cachePath) && new FileInfo(cachePath).Length > 0)
+            {
+                Log($"ServeAppleCompatibleMp4: 命中 Apple 兼容缓存 {cachePath}");
+                ServeFileWithRange(ctx, cachePath, inline: true);
+                return;
+            }
+
+            string ffmpegPath = AppPaths.FindFFmpeg();
+            if (string.IsNullOrEmpty(ffmpegPath) || !File.Exists(ffmpegPath))
+            {
+                Log("ServeAppleCompatibleMp4: 未找到 ffmpeg，直接传输原片");
+                ServeFileWithRange(ctx, filePath, inline: true);
+                return;
+            }
+
+            Directory.CreateDirectory(_transCacheDir);
+            string tmpPath = Path.Combine(_transCacheDir, $"{Guid.NewGuid():N}.tmp.mp4");
+            string args = $"-loglevel warning -y -i \"{filePath}\" -map 0:v:0 -map 0:a? -c copy -tag:v hvc1 -movflags +faststart -f mp4 \"{tmpPath}\"";
+
+            IDisposable ffmpegSlot = null;
+            try
+            {
+                ffmpegSlot = _ffmpegWorkLimiter.Enter(_cts.Token);
+                Log($"ServeAppleCompatibleMp4: 流拷贝 hev1→hvc1 {filePath}");
+                if (!TryRunFFmpeg(ffmpegPath, args, tmpPath))
+                {
+                    Log("ServeAppleCompatibleMp4: 流拷贝失败，直接传输原片");
+                    try { File.Delete(tmpPath); } catch { }
+                    ServeFileWithRange(ctx, filePath, inline: true);
+                    return;
+                }
+                try { File.Move(tmpPath, cachePath, overwrite: true); } catch { }
+                Task.Run(CleanWebCache);
+                ServeFileWithRange(ctx, File.Exists(cachePath) ? cachePath : tmpPath, inline: true);
+            }
+            catch (OperationCanceledException)
+            {
+                try { File.Delete(tmpPath); } catch { }
+                try { ctx.Response.Abort(); } catch { }
+            }
+            finally
+            {
+                ffmpegSlot?.Dispose();
+            }
+        }
+
         // ───── FFmpeg 转码：命中缓存直接 Range 传输，否则边转码边推流 + 同时写缓存 ─────
         private void ServeTranscodedStream(HttpListenerContext ctx, string filePath)
         {
@@ -3320,6 +3393,29 @@ namespace ExpressPackingMonitoring.Services
                 string hwArgs = $"-loglevel warning -hwaccel auto -i \"{filePath}\" {scaleFilter} -c:v h264_nvenc -preset p1 -cq 30 -c:a aac -b:a 96k -movflags frag_keyframe+empty_moov+default_base_moof -f mp4 pipe:1";
                 string swArgs = $"-loglevel warning -i \"{filePath}\" {scaleFilter} -c:v libx264 -preset ultrafast -tune zerolatency -crf 28 -c:a aac -b:a 96k -movflags frag_keyframe+empty_moov+default_base_moof -f mp4 pipe:1";
 
+                // iOS AVPlayer 依赖 Range/206：边转码边推流的 chunked 响应会被判定为
+                // serverIncorrectlyConfigured(-12939)。Apple 客户端先完整转码进缓存，
+                // 再按标准 Range 传输；浏览器继续保留边转码边推流的低延迟行为。
+                if (IsAppleCoreMediaRequest(ctx))
+                {
+                    bool transcoded = TranscodeToFile(ffmpegPath, hwArgs, tmpPath);
+                    if (!transcoded)
+                    {
+                        Log("ServeTranscodedStream: NVENC 预转码失败，回退 CPU");
+                        transcoded = TranscodeToFile(ffmpegPath, swArgs, tmpPath);
+                    }
+                    if (!transcoded)
+                    {
+                        try { File.Delete(tmpPath); } catch { }
+                        SendJson(ctx, 500, new { errorCode = "transcode_failed", error = "电脑端转码失败，请稍后重试" });
+                        return;
+                    }
+                    try { File.Move(tmpPath, cachePath, overwrite: true); } catch { }
+                    Task.Run(CleanWebCache);
+                    ServeFileWithRange(ctx, File.Exists(cachePath) ? cachePath : tmpPath, inline: true);
+                    return;
+                }
+
                 if (!StreamTranscodeToClient(ctx, ffmpegPath, hwArgs, tmpPath))
                 {
                     Log("ServeTranscodedStream: NVENC 流式转码失败，回退 CPU");
@@ -3345,6 +3441,13 @@ namespace ExpressPackingMonitoring.Services
                     _transcodeSlot.Release();
             }
         }
+
+        private static bool IsAppleCoreMediaRequest(HttpListenerContext ctx)
+            => IsAppleCoreMediaUserAgent(ctx.Request.UserAgent);
+
+        internal static bool IsAppleCoreMediaUserAgent(string? userAgent)
+            => userAgent != null
+               && userAgent.Contains("AppleCoreMedia", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// 启动 FFmpeg，将 stdout 同时推送给浏览器和写入缓存文件。
@@ -3414,6 +3517,64 @@ namespace ExpressPackingMonitoring.Services
             {
                 Log($"StreamTranscodeToClient 异常: {ex.Message}");
                 try { ctx.Response.Abort(); } catch { }
+                try { File.Delete(tmpPath); } catch { }
+                return false;
+            }
+            finally
+            {
+                cacheFs?.Dispose();
+                if (proc != null && !proc.HasExited) { try { proc.Kill(); } catch { } }
+                proc?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// 启动 FFmpeg 并将 stdout 完整写入临时文件，不向客户端发送字节。
+        /// 返回 true 表示 FFmpeg 正常退出且已生成非空文件。
+        /// </summary>
+        private bool TranscodeToFile(string ffmpegPath, string args, string tmpPath)
+        {
+            Log($"TranscodeToFile: {args}");
+            var psi = new ProcessStartInfo
+            {
+                FileName = ffmpegPath,
+                Arguments = args,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            Process proc = null;
+            FileStream cacheFs = null;
+            try
+            {
+                proc = Process.Start(psi);
+                if (proc == null) return false;
+
+                var stderrBuf = new StringBuilder();
+                proc.ErrorDataReceived += (_, e) => { if (e.Data != null) stderrBuf.AppendLine(e.Data); };
+                proc.BeginErrorReadLine();
+
+                cacheFs = new FileStream(tmpPath, FileMode.Create, FileAccess.Write, FileShare.None);
+                byte[] buffer = new byte[65536];
+                using var stdout = proc.StandardOutput.BaseStream;
+                int read;
+                while ((read = stdout.Read(buffer, 0, buffer.Length)) > 0)
+                    cacheFs.Write(buffer, 0, read);
+
+                cacheFs.Close();
+                cacheFs = null;
+                proc.WaitForExit(5000);
+                string stderr = stderrBuf.ToString();
+                Log($"TranscodeToFile: 退出码={proc.ExitCode}, stderr={stderr}");
+                return proc.ExitCode == 0
+                    && File.Exists(tmpPath)
+                    && new FileInfo(tmpPath).Length > 0;
+            }
+            catch (Exception ex)
+            {
+                Log($"TranscodeToFile 异常: {ex.Message}");
                 try { File.Delete(tmpPath); } catch { }
                 return false;
             }

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -3318,7 +3318,7 @@ namespace ExpressPackingMonitoring.Services
             string tmpPath = Path.Combine(_transCacheDir, $"{Guid.NewGuid():N}.tmp.mp4");
             string args = $"-loglevel warning -y -i \"{filePath}\" -map 0:v:0 -map 0:a? -c copy -tag:v hvc1 -movflags +faststart -f mp4 \"{tmpPath}\"";
 
-            IDisposable ffmpegSlot = null;
+            IDisposable? ffmpegSlot = null;
             try
             {
                 ffmpegSlot = _ffmpegWorkLimiter.Enter(_cts.Token);
@@ -3545,8 +3545,8 @@ namespace ExpressPackingMonitoring.Services
                 CreateNoWindow = true
             };
 
-            Process proc = null;
-            FileStream cacheFs = null;
+            Process? proc = null;
+            FileStream? cacheFs = null;
             try
             {
                 proc = Process.Start(psi);

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -3145,10 +3145,10 @@ namespace ExpressPackingMonitoring.Services
             bool shouldTranscode = compatMode && codec != "" && codec != "h264";
             bool recording = _isRecordingProvider();
             bool hasTranscodeCache = shouldTranscode && HasTranscodeCache(filePath);
-            bool appleCoreMedia = IsAppleCoreMediaRequest(ctx);
+            bool appleClient = IsApplePlaybackClientRequest(ctx);
             string userAgent = ctx.Request.UserAgent ?? "";
             if (userAgent.Length > 120) userAgent = userAgent.Substring(0, 120);
-            Log($"HandlePlay: codec='{codec}', compat={(compatMode ? "1" : "0")}, 判定={(shouldTranscode ? "转码" : "直传")}, appleCoreMedia={appleCoreMedia}, ua={userAgent}");
+            Log($"HandlePlay: codec='{codec}', compat={(compatMode ? "1" : "0")}, 判定={(shouldTranscode ? "转码" : "直传")}, appleClient={appleClient}, ua={userAgent}");
 
             if (shouldTranscode && recording && !allowTranscodeWhileRecording && !hasTranscodeCache)
             {
@@ -3176,7 +3176,7 @@ namespace ExpressPackingMonitoring.Services
             {
                 ServeTranscodedStream(ctx, filePath);
             }
-            else if (appleCoreMedia && IsHevcVideoCodec(codec)
+            else if (appleClient && IsHevcVideoCodec(codec)
                 && filePath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase))
             {
                 ServeAppleCompatibleMp4(ctx, filePath);
@@ -3396,7 +3396,7 @@ namespace ExpressPackingMonitoring.Services
                 // iOS AVPlayer 依赖 Range/206：边转码边推流的 chunked 响应会被判定为
                 // serverIncorrectlyConfigured(-12939)。Apple 客户端先完整转码进缓存，
                 // 再按标准 Range 传输；浏览器继续保留边转码边推流的低延迟行为。
-                if (IsAppleCoreMediaRequest(ctx))
+                if (IsApplePlaybackClientRequest(ctx))
                 {
                     bool transcoded = TranscodeToFile(ffmpegPath, hwArgs, tmpPath);
                     if (!transcoded)
@@ -3442,12 +3442,29 @@ namespace ExpressPackingMonitoring.Services
             }
         }
 
-        private static bool IsAppleCoreMediaRequest(HttpListenerContext ctx)
-            => IsAppleCoreMediaUserAgent(ctx.Request.UserAgent);
+        private static bool IsApplePlaybackClientRequest(HttpListenerContext ctx)
+            => IsApplePlaybackClientUserAgent(ctx.Request.UserAgent);
 
-        internal static bool IsAppleCoreMediaUserAgent(string userAgent)
-            => userAgent != null
-               && userAgent.Contains("AppleCoreMedia", StringComparison.OrdinalIgnoreCase);
+        /// <summary>
+        /// 识别 Apple 媒体播放客户端：iOS/AVFoundation 的媒体请求带 AppleCoreMedia UA；
+        /// macOS Safari 的 video 媒体请求使用普通 Safari UA，不含 AppleCoreMedia，
+        /// 因此额外识别“Macintosh + Safari/ 且非 Chrome/Edge/Opera”，
+        /// 让 Safari 同样进入 hev1→hvc1 拷贝与 Range 转码分支。
+        /// </summary>
+        internal static bool IsApplePlaybackClientUserAgent(string userAgent)
+        {
+            if (userAgent == null)
+                return false;
+
+            if (userAgent.Contains("AppleCoreMedia", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return userAgent.Contains("Safari/", StringComparison.OrdinalIgnoreCase)
+                && userAgent.Contains("Macintosh", StringComparison.OrdinalIgnoreCase)
+                && !userAgent.Contains("Chrome/", StringComparison.OrdinalIgnoreCase)
+                && !userAgent.Contains("Edg/", StringComparison.OrdinalIgnoreCase)
+                && !userAgent.Contains("OPR/", StringComparison.OrdinalIgnoreCase);
+        }
 
         /// <summary>
         /// 启动 FFmpeg，将 stdout 同时推送给浏览器和写入缓存文件。

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -3318,7 +3318,7 @@ namespace ExpressPackingMonitoring.Services
             string tmpPath = Path.Combine(_transCacheDir, $"{Guid.NewGuid():N}.tmp.mp4");
             string args = $"-loglevel warning -y -i \"{filePath}\" -map 0:v:0 -map 0:a? -c copy -tag:v hvc1 -movflags +faststart -f mp4 \"{tmpPath}\"";
 
-            IDisposable? ffmpegSlot = null;
+            IDisposable ffmpegSlot = null;
             try
             {
                 ffmpegSlot = _ffmpegWorkLimiter.Enter(_cts.Token);
@@ -3445,7 +3445,7 @@ namespace ExpressPackingMonitoring.Services
         private static bool IsAppleCoreMediaRequest(HttpListenerContext ctx)
             => IsAppleCoreMediaUserAgent(ctx.Request.UserAgent);
 
-        internal static bool IsAppleCoreMediaUserAgent(string? userAgent)
+        internal static bool IsAppleCoreMediaUserAgent(string userAgent)
             => userAgent != null
                && userAgent.Contains("AppleCoreMedia", StringComparison.OrdinalIgnoreCase);
 
@@ -3545,8 +3545,8 @@ namespace ExpressPackingMonitoring.Services
                 CreateNoWindow = true
             };
 
-            Process? proc = null;
-            FileStream? cacheFs = null;
+            Process proc = null;
+            FileStream cacheFs = null;
             try
             {
                 proc = Process.Start(psi);

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -3187,7 +3187,7 @@ namespace ExpressPackingMonitoring.Services
             }
         }
 
-        private static bool IsHevcVideoCodec(string codec)
+        internal static bool IsHevcVideoCodec(string codec)
             => codec == "h265" || codec == "hevc";
 
         private string EnsureMp4ContainerForPlayback(HttpListenerContext ctx, VideoRecord record)

--- a/ExpressPackingMonitoring/ViewModels/MainViewModel.Recording.cs
+++ b/ExpressPackingMonitoring/ViewModels/MainViewModel.Recording.cs
@@ -2273,7 +2273,7 @@ namespace ExpressPackingMonitoring.ViewModels
                 var psi = new ProcessStartInfo
                 {
                     FileName = ffmpegPath,
-                    Arguments = BuildMkvToMp4Args(mkvPath, audioPath, mp4Path, Config.AudioSyncOffsetMs),
+                    Arguments = BuildMkvToMp4Args(mkvPath, audioPath, mp4Path, Config.AudioSyncOffsetMs, Config.VideoCodec),
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     RedirectStandardError = true,
@@ -2343,7 +2343,9 @@ namespace ExpressPackingMonitoring.ViewModels
                 }
             }
 
-            MkvConversionResult result = ConvertMkvToMp4ForPlayback(filePath);
+            MkvConversionResult result = ConvertMkvToMp4ForPlayback(
+                filePath,
+                videoCodec: record.VideoCodec);
             if (result.Success)
                 _db?.ClearMkvConversionFailure(filePath);
             else
@@ -2351,7 +2353,10 @@ namespace ExpressPackingMonitoring.ViewModels
             return result;
         }
 
-        private MkvConversionResult ConvertMkvToMp4ForPlayback(string mkvPath, CancellationToken cancellationToken = default)
+        private MkvConversionResult ConvertMkvToMp4ForPlayback(
+            string mkvPath,
+            CancellationToken cancellationToken = default,
+            string? videoCodec = null)
         {
             bool lockTaken = false;
             try
@@ -2416,7 +2421,7 @@ namespace ExpressPackingMonitoring.ViewModels
                 var psi = new ProcessStartInfo
                 {
                     FileName = ffmpegPath,
-                    Arguments = BuildMkvToMp4Args(mkvPath, audioPath, mp4Path, Config.AudioSyncOffsetMs),
+                    Arguments = BuildMkvToMp4Args(mkvPath, audioPath, mp4Path, Config.AudioSyncOffsetMs, videoCodec),
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     RedirectStandardError = true,
@@ -2519,10 +2524,21 @@ namespace ExpressPackingMonitoring.ViewModels
                 || (!string.IsNullOrWhiteSpace(audioLogPath) && File.Exists(audioLogPath));
         }
 
-        internal static string BuildMkvToMp4Args(string mkvPath, string? audioPath, string mp4Path, int audioSyncOffsetMs)
+        internal static string BuildMkvToMp4Args(
+            string mkvPath,
+            string? audioPath,
+            string mp4Path,
+            int audioSyncOffsetMs,
+            string? videoCodec = null)
         {
+            // 苹果解码器只认 hvc1 标签，NVENC 默认写出的 hev1 在 iOS 上无法解码；
+            // 仅在确认为 HEVC 时为视频轨写 hvc1，其他编码保持 movenc 默认标签。
+            string hevcTag = videoCodec is "h265" or "hevc"
+                ? " -tag:v hvc1"
+                : "";
+
             if (string.IsNullOrEmpty(audioPath) || !File.Exists(audioPath))
-                return $"-y -i \"{mkvPath}\" -map 0:v:0 -map 0:a? -c copy \"{mp4Path}\"";
+                return $"-y -i \"{mkvPath}\" -map 0:v:0 -map 0:a? -c copy{hevcTag} \"{mp4Path}\"";
 
             int offsetMs = Math.Clamp(audioSyncOffsetMs, -5000, 5000);
             string audioMap = "[a]";
@@ -2542,7 +2558,7 @@ namespace ExpressPackingMonitoring.ViewModels
                 filter = " -filter_complex \"[1:a]apad[a]\"";
             }
 
-            return $"-y -i \"{mkvPath}\" -i \"{audioPath}\"{filter} -map 0:v:0 -map \"{audioMap}\" -c:v copy -c:a aac -b:a 128k -shortest \"{mp4Path}\"";
+            return $"-y -i \"{mkvPath}\" -i \"{audioPath}\"{filter} -map 0:v:0 -map \"{audioMap}\" -c:v copy{hevcTag} -c:a aac -b:a 128k -shortest \"{mp4Path}\"";
         }
 
         private bool ValidateConvertedMp4(


### PR DESCRIPTION
## 背景

iOS/模拟器查看电脑端 H.265 录像时出现两类问题：

1. 直传原片：电脑端 NVENC 写出的 MP4 使用 hev1 采样标签，Apple 解码器无法解码（白屏、Cannot Decode）。
2. 走转码：首次播放边转码边推流的 chunked 响应被 iOS 18 AVPlayer 判定为 serverIncorrectlyConfigured（-12939）。

## 改动

- AppleCoreMedia（iOS AVPlayer / Safari）客户端直传 H.265 时，用 ffmpeg 纯流拷贝 `-tag:v hvc1` 生成 Apple 兼容副本并缓存，按 Range/206 传输；不重新编码、不降画质、只做一次。ffmpeg 不可用或失败时回退直传原片。
- AppleCoreMedia 发起的转码请求改为先完整转码再按 Range 传输，规避 -12939；浏览器仍保持边转码边推流。
- HandlePlay 日志增加客户端 UA 与 appleCoreMedia 标记，便于排查。
- 新增 UA 识别与 HEVC 编码别名单测。

## 验证

- Mac 本机 AVFoundation 实测：hev1 原片 isPlayable=false；仅改标签为 hvc1 后可正常解码出帧。
- 依赖 CI 在 windows-latest 验证编译与全部单测。