### PR TITLE
fix: 设备剪辑中文文件名票据二次转义导致下载 401

### DIFF
--- a/ExpressPackingMonitoring.Tests/MobileBackupTests.cs
+++ b/ExpressPackingMonitoring.Tests/MobileBackupTests.cs
@@ -170,6 +170,21 @@ public sealed class MobileBackupTests
     }
 
     [Fact]
+    public void DeviceClipAssetFileNameDecodesChineseBeforeRebuildingTicketUrl()
+    {
+        const string sourceName = "YT0702565090843_20260814_181812_发货";
+        string outputName = $"{sourceName}_clip_20260814_203000.mp4";
+        string escapedAssetPath = "/api/clips/" + Uri.EscapeDataString(outputName);
+
+        string fileName = WebServer.ResolveDeviceClipAssetFileName(escapedAssetPath);
+        Assert.Equal(outputName, fileName);
+
+        string assetUrl = "/api/mobile-backup/clips/" + Uri.EscapeDataString(fileName) + "?ticket=abc";
+        Uri decodedRequest = new("http://127.0.0.1:5280" + assetUrl);
+        Assert.Equal(fileName, Path.GetFileName(decodedRequest.AbsolutePath));
+    }
+
+    [Fact]
     public void LegacyCacheMobileBackupStateMigratesToDurableStateDirectory()
     {
         string directory = CreateTempDirectory();

--- a/ExpressPackingMonitoring/Services/WebServer.cs
+++ b/ExpressPackingMonitoring/Services/WebServer.cs
@@ -1886,7 +1886,7 @@ namespace ExpressPackingMonitoring.Services
                     : _clipService.CreateTimelinePreviews(recordId, request.FrameCount);
                 foreach (ClipTimelineFrame frame in result.Frames)
                 {
-                    string fileName = Path.GetFileName(frame.Url);
+                    string fileName = ResolveDeviceClipAssetFileName(frame.Url);
                     string ticket = CreateDeviceClipAssetTicket(deviceId, fileName, "preview");
                     frame.Url = $"/api/mobile-backup/clip-previews/{Uri.EscapeDataString(fileName)}?ticket={ticket}";
                 }
@@ -1934,13 +1934,16 @@ namespace ExpressPackingMonitoring.Services
             }
             if (!string.IsNullOrWhiteSpace(task.DownloadUrl))
             {
-                string fileName = Path.GetFileName(task.DownloadUrl);
+                string fileName = ResolveDeviceClipAssetFileName(task.DownloadUrl);
                 string ticket = CreateDeviceClipAssetTicket(deviceId, fileName, "clip");
                 task.DownloadUrl = $"/api/mobile-backup/clips/{Uri.EscapeDataString(fileName)}?ticket={ticket}";
                 task.PlayUrl = task.DownloadUrl + "&inline=1";
             }
             SendJson(ctx, 200, task);
         }
+
+        internal static string ResolveDeviceClipAssetFileName(string escapedAssetPath) =>
+            Uri.UnescapeDataString(Path.GetFileName(escapedAssetPath));
 
         private void HandleCancelDeviceClipTask(HttpListenerContext ctx, string path)
         {


### PR DESCRIPTION
## 问题

iOS 从电脑端生成剪辑后下载剪辑文件时返回 401，电脑端日志显示 `enrollment_required`。

## 原因

设备剪辑输出文件名包含中文（如 `..._发货_clip_....mp4`）时：

1. 任务创建时先对文件名做了一次转义；
2. `HandleGetDeviceClipTask` 取该转义结果再转义一次并作为票据文件名；
3. 手机按链接请求后，服务端解码得到的文件名与票据中记录的文件名不一致，票据校验失败，最终落回设备认证分支并返回 401。

## 修改

- 新增 `WebServer.ResolveDeviceClipAssetFileName`，先解码出原始文件名，再生成票据和单次转义的下载链接；
- 剪辑预览和剪辑下载两条路径统一使用该逻辑；
- 增加中文文件名回环回归测试。

## 验证

- `dotnet test ExpressPackingMonitoring.Tests/ExpressPackingMonitoring.Tests.csproj -c Debug` 由 CI 执行