### PR TITLE
fix: 手机发送“本机”时电脑自动生成手机编号

### DIFF
--- a/ExpressPackingMonitoring/Services/MobileOrderReceiverRegistry.cs
+++ b/ExpressPackingMonitoring/Services/MobileOrderReceiverRegistry.cs
@@ -142,6 +142,7 @@ internal sealed class MobileOrderReceiverRegistry
     {
         string value = name?.Trim() ?? "";
         return value.Length == 0
+            || value.Equals("本机", StringComparison.Ordinal)
             || value.Equals("设备", StringComparison.Ordinal)
             || value.StartsWith("设备 ", StringComparison.Ordinal)
             || value.StartsWith("手机录像设备 ", StringComparison.Ordinal)


### PR DESCRIPTION
手机端默认名改为“本机”后，电脑端未识别为自动名称，导致设备列表显示“本机”。本次把“本机”加入自动名称判断，由电脑按现有规则生成“手机1”“手机2”。\n\n验证：Windows 本机 dotnet test 1366 个测试全部通过。